### PR TITLE
getClient() method to allow access to the guzzle client

### DIFF
--- a/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
@@ -307,4 +307,10 @@ class UserPasswordSpec extends ObjectBehavior
         $this->request('uri',['format'=>'xml'])->shouldReturn('xmlResource');
     }
 
+    function it_allows_access_to_the_guzzle_client(
+        ClientInterface $mockedClient)
+    {
+        $this->getClient()->shouldReturn($mockedClient);
+    }
+
 }

--- a/spec/Omniphx/Forrest/Authentications/WebServerSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/WebServerSpec.php
@@ -627,4 +627,10 @@ class WebServerSpec extends ObjectBehavior
         $this->delete('delete')->shouldReturn($mockedResponse);
     }
 
+    function it_allows_access_to_the_guzzle_client(
+        ClientInterface $mockedClient)
+    {
+        $this->getClient()->shouldReturn($mockedClient);
+    }
+
 }

--- a/src/Omniphx/Forrest/Resource.php
+++ b/src/Omniphx/Forrest/Resource.php
@@ -31,6 +31,16 @@ abstract class Resource {
     private $headers;
 
     /**
+     * Public accessor to the Guzzle Client Object
+     *
+     * @return GuzzleHttp\ClientInterface
+     */
+    public function getClient()
+    {
+        return $this->client;
+    }
+
+    /**
      * Method returns the response for the requested resource
      * @param  string $pURI 
      * @param  array  $pOptions


### PR DESCRIPTION
I needed to append event tracking somehow. I can use guzzle Emitter if I have access to the object.