### PR TITLE
Fire a laravel event on API response

### DIFF
--- a/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Message\RequestInterface;
 use Omniphx\Forrest\Interfaces\StorageInterface;
 use Omniphx\Forrest\Interfaces\RedirectInterface;
 use Omniphx\Forrest\Interfaces\InputInterface;
+use Omniphx\Forrest\Interfaces\EventInterface;
 
 class UserPasswordSpec extends ObjectBehavior
 {
@@ -20,7 +21,8 @@ class UserPasswordSpec extends ObjectBehavior
         RequestInterface $mockedRequest,
         StorageInterface $mockedStorage,
         RedirectInterface $mockedRedirect,
-        InputInterface $mockedInput) {
+        InputInterface $mockedInput,
+        EventInterface $mockedEvent) {
 
         $settings  = array(
             'authenticationFlow' => 'UserPassword',
@@ -86,6 +88,7 @@ class UserPasswordSpec extends ObjectBehavior
             $mockedStorage,
             $mockedRedirect,
             $mockedInput,
+            $mockedEvent,
             $settings);
 
     }

--- a/spec/Omniphx/Forrest/Authentications/WebServerSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/WebServerSpec.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Message\RequestInterface;
 use Omniphx\Forrest\Interfaces\StorageInterface;
 use Omniphx\Forrest\Interfaces\RedirectInterface;
 use Omniphx\Forrest\Interfaces\InputInterface;
+use Omniphx\Forrest\Interfaces\EventInterface;
 
 class WebServerSpec extends ObjectBehavior
 {
@@ -20,7 +21,8 @@ class WebServerSpec extends ObjectBehavior
         RequestInterface $mockedRequest,
         StorageInterface $mockedStorage,
         RedirectInterface $mockedRedirect,
-        InputInterface $mockedInput)
+        InputInterface $mockedInput,
+        EventInterface $mockedEvent)
     {
         $settings  = array(
             'creditials' => array(
@@ -88,6 +90,7 @@ class WebServerSpec extends ObjectBehavior
             $mockedStorage,
             $mockedRedirect,
             $mockedInput,
+            $mockedEvent,
             $settings);
     }
 
@@ -631,6 +634,19 @@ class WebServerSpec extends ObjectBehavior
         ClientInterface $mockedClient)
     {
         $this->getClient()->shouldReturn($mockedClient);
+    }
+
+    function it_should_fire_a_response_event (
+        ClientInterface $mockedClient,
+        EventInterface $mockedEvent,
+        RequestInterface $mockedRequest,
+        ResponseInterface $mockedResponse)
+    {
+        $mockedClient->createRequest(Argument::any(),Argument::any(),Argument::any())->willReturn($mockedRequest);
+        $mockedClient->send(Argument::any(),Argument::any(),Argument::any())->willReturn($mockedResponse);
+        $mockedEvent->fire('forrest.response', Argument::any())->shouldBeCalled();
+
+        $this->versions();
     }
 
 }

--- a/spec/Omniphx/Forrest/Providers/Laravel/LaravelEventSpec.php
+++ b/spec/Omniphx/Forrest/Providers/Laravel/LaravelEventSpec.php
@@ -1,0 +1,14 @@
+<?php namespace spec\Omniphx\Forrest\Providers\Laravel;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class LaravelEventSpec extends ObjectBehavior
+{
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Omniphx\Forrest\Providers\Laravel\LaravelEvent');
+    }
+
+}

--- a/src/Omniphx/Forrest/Authentications/UserPassword.php
+++ b/src/Omniphx/Forrest/Authentications/UserPassword.php
@@ -5,6 +5,7 @@ use GuzzleHttp\ClientInterface;
 use Omniphx\Forrest\Interfaces\StorageInterface;
 use Omniphx\Forrest\Interfaces\RedirectInterface;
 use Omniphx\Forrest\Interfaces\InputInterface;
+use Omniphx\Forrest\Interfaces\EventInterface;
 use Omniphx\Forrest\Interfaces\UserPasswordInterface;
 use Omniphx\Forrest\Exceptions\TokenExpiredException;
 
@@ -33,12 +34,14 @@ class UserPassword extends Client implements UserPasswordInterface
         StorageInterface $storage,
         RedirectInterface $redirect,
         InputInterface $input,
+        EventInterface $event,
         $settings)
     {
         $this->client     = $client;
         $this->storage    = $storage;
         $this->redirect   = $redirect;
         $this->input      = $input;
+        $this->event      = $event;
         $this->settings   = $settings;
         $this->creditials = $settings['creditials'];
     }

--- a/src/Omniphx/Forrest/Authentications/WebServer.php
+++ b/src/Omniphx/Forrest/Authentications/WebServer.php
@@ -6,6 +6,7 @@ use Omniphx\Forrest\Client;
 use Omniphx\Forrest\Interfaces\StorageInterface;
 use Omniphx\Forrest\Interfaces\RedirectInterface;
 use Omniphx\Forrest\Interfaces\InputInterface;
+use Omniphx\Forrest\Interfaces\EventInterface;
 use Omniphx\Forrest\Interfaces\WebServerInterface;
 use Omniphx\Forrest\Exceptions\TokenExpiredException;
 
@@ -41,12 +42,14 @@ class WebServer extends Client implements WebServerInterface
         StorageInterface $storage,
         RedirectInterface $redirect,
         InputInterface $input,
+        EventInterface $event,
         $settings)
     {
         $this->client   = $client;
         $this->storage  = $storage;
         $this->redirect = $redirect;
         $this->input    = $input;
+        $this->event    = $event;
         $this->settings = $settings;
         $this->creditials = $settings['creditials'];
         $this->parameters = $settings['parameters'];

--- a/src/Omniphx/Forrest/Interfaces/EventInterface.php
+++ b/src/Omniphx/Forrest/Interfaces/EventInterface.php
@@ -1,0 +1,15 @@
+<?php namespace Omniphx\Forrest\Interfaces;
+
+interface EventInterface {
+
+    /**
+    * Fire an event and call the listeners.
+    *
+    * @param  string  $event
+    * @param  mixed   $payload
+    * @param  bool    $halt
+    * @return array|null
+    */
+    public function fire($event, $payload = array(), $halt = false);
+
+}

--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelEvent.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelEvent.php
@@ -1,0 +1,19 @@
+<?php namespace Omniphx\Forrest\Providers\Laravel;
+
+use Omniphx\Forrest\Interfaces\EventInterface;
+use Event;
+
+class LaravelEvent implements EventInterface {
+
+	/**
+	 * Fire an event and call the listeners.
+	 *
+	 * @param  string  $event
+	 * @param  mixed   $payload
+	 * @param  bool    $halt
+	 * @return array|null
+	 */
+	public function fire($event, $payload = array(), $halt = false) {
+		return Event::fire($event, $payload, $halt);
+	}
+}

--- a/src/Omniphx/Forrest/Resource.php
+++ b/src/Omniphx/Forrest/Resource.php
@@ -65,12 +65,16 @@ abstract class Resource {
 
         try {
             $response = $this->client->send($request);
+
+            $this->event->fire('forrest.response', array($request));
+
+            return $this->responseFormat($response,$format);
+
         } catch(RequestException $e) {
             $this->assignExceptions($e);
         }
 
-        return $this->responseFormat($response,$format);
-        
+
     }
 
     /**


### PR DESCRIPTION
I'm learning how to write better tests from studying your code :)
This commit just adds laravel Event::fire('forrest.response', array($request)); to the requestResource method. Allowing developers to use an event listener to catch the response if they want. (in my case I will use it for logging the response and request)