### PR TITLE
Allow external access to token

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -487,7 +487,7 @@ abstract class Client {
      * Get token
      * @return array
      */
-    protected function getToken()
+    public function getToken()
     {
         return $this->storage->getToken();
     }


### PR DESCRIPTION
There is no other way to check that a token already exists, apparently.