### PR TITLE
Fix config references

### DIFF
--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelCache.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelCache.php
@@ -15,11 +15,11 @@ class LaravelCache extends LaravelStorageProvider implements StorageInterface {
 
 	public function __construct(Config $config, Cache $cache)
 	{
-		$this->path = $config->get('forrest::config.storage.path');
+		$this->path = $config->get('forrest.storage.path');
 
 		$this->cache = $cache;
 
-		if($minutes = $config->get('forrest::config.storage.expire_in')) {
+		if($minutes = $config->get('forrest.storage.expire_in')) {
 			$this->minutes = $minutes;
 		}
 	}

--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelSession.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelSession.php
@@ -13,7 +13,7 @@ class LaravelSession extends LaravelStorageProvider implements StorageInterface 
 
 	public function __construct(Config $config, Session $session)
 	{
-		$this->path = $config->get('forrest::config.storage.path');
+		$this->path = $config->get('forrest.storage.path');
 
 		$this->session = $session;
 	}

--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelStorageProvider.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelStorageProvider.php
@@ -29,7 +29,7 @@ abstract class LaravelStorageProvider implements StorageInterface {
             return Crypt::decrypt($token);
         }
 
-        throw new MissingTokenException(sprintf('No token available in \''.\Config::get('forrest::config.storage.type').'\' storage'));
+        throw new MissingTokenException(sprintf('No token available in \''.\Config::get('forrest.storage.type').'\' storage'));
     }
 
     /**


### PR DESCRIPTION
I noticed that my cache was expiring really quickly, despite setting a high value in the settings...

It looks like the legacy config naming convention was in use in a few places, which doesn't seem to work with Laravel 5.

Updating the code as per this pull request seemed to fix the issue.