### PR TITLE
Removed race-condition in token handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 composer.phar
 composer.lock
 .DS_Store
+/.idea
 /src/config/local
 /src/config/production
 mm.log

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -26,6 +26,13 @@ abstract class Client
     protected $storage;
 
     /**
+     * Token data.
+     *
+     * @var array
+     */
+    protected $tokenData;
+
+    /**
      * Reqeust headers.
      *
      * @var array
@@ -535,7 +542,11 @@ abstract class Client
      */
     public function getTokenData()
     {
-        return $this->storage->getTokenData();
+        if (empty($this->tokenData)) {
+            $this->tokenData = $this->storage->getTokenData();
+        }
+
+        return $this->tokenData;
     }
 
     /**
@@ -647,7 +658,7 @@ abstract class Client
     {
         $format = $options['format'];
 
-        $authToken = $this->storage->getTokenData();
+        $authToken = $this->getTokenData();
 
         $accessToken = $authToken['access_token'];
         $tokenType = $authToken['token_type'];


### PR DESCRIPTION
A race condition existed in the handling of the token data when the cache invalidates the token data anytime between the first request for it and the final. This is corrected by saving the token data to the object, making the token data automic per request.