### PR TITLE
Improved code quality

### DIFF
--- a/src/Omniphx/Forrest/Authentications/UserPassword.php
+++ b/src/Omniphx/Forrest/Authentications/UserPassword.php
@@ -16,14 +16,14 @@ class UserPassword extends Client implements UserPasswordInterface
     /**
      * Redirect handler.
      *
-     * @var Redirect
+     * @var RedirectInterface
      */
     protected $redirect;
 
     /**
      * Interface for Input calls.
      *
-     * @var Omniphx\Forrest\Interfaces\InputInterface
+     * @var InputInterface
      */
     protected $input;
 

--- a/src/Omniphx/Forrest/Authentications/WebServer.php
+++ b/src/Omniphx/Forrest/Authentications/WebServer.php
@@ -16,14 +16,14 @@ class WebServer extends Client implements WebServerInterface
     /**
      * Redirect handler.
      *
-     * @var Redirect
+     * @var RedirectInterface
      */
     protected $redirect;
 
     /**
      * Inteface for Input calls.
      *
-     * @var Omniphx\Forrest\Interfaces\InputInterface
+     * @var \Omniphx\Forrest\Interfaces\InputInterface
      */
     protected $input;
 
@@ -63,7 +63,9 @@ class WebServer extends Client implements WebServerInterface
      * Call this method to redirect user to login page and initiate
      * the Web Server OAuth Authentication Flow.
      *
-     * @return void
+     * @param null $loginURL
+     *
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function authenticate($loginURL = null)
     {
@@ -106,7 +108,6 @@ class WebServer extends Client implements WebServerInterface
     {
         //Salesforce sends us an authorization code as part of the Web Server OAuth Authentication Flow
         $code = $this->input->get('code');
-        $state = $this->input->get('state');
 
         //Now we must make a request for the authorization token.
         $tokenURL = $this->credentials['loginURL'].'/services/oauth2/token';
@@ -133,8 +134,6 @@ class WebServer extends Client implements WebServerInterface
 
     /**
      * Refresh authentication token.
-     *
-     * @param array $refreshToken
      *
      * @return mixed $response
      */

--- a/src/Omniphx/Forrest/Interfaces/RedirectInterface.php
+++ b/src/Omniphx/Forrest/Interfaces/RedirectInterface.php
@@ -9,7 +9,7 @@ interface RedirectInterface
      *
      * @param string $parameter
      *
-     * @return void
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function to($parameter);
 }

--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelRedirect.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelRedirect.php
@@ -12,7 +12,7 @@ class LaravelRedirect implements RedirectInterface
      *
      * @param string $parameter
      *
-     * @return void
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function to($parameter)
     {


### PR DESCRIPTION
Reduced copy/paste code in methods
Aligned abstract client class with the interface implicitly formed by the two children
Corrected return types
Removed unused variables; In some cases left the getter call to preserve any exception throwing behavior if those getters fail
Correct DocBlock annotations on parameters and return types. Unless we are going to go to lengths to fully wrap the redirect then we ought to just return Laravel 5's RedirectResponse.