### PR TITLE
Improve exception handling

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -767,12 +767,12 @@ abstract class Client
      */
     private function assignExceptions(RequestException $e)
     {
-        if ($e->hasResponse() && $e->getResponse()->getStatusCode() == '401') {
-            throw new TokenExpiredException(sprintf('Salesforce token has expired'));
+        if ($e->hasResponse() && $e->getResponse()->getStatusCode() == 401) {
+            throw new TokenExpiredException('Salesforce token has expired', $e);
         } elseif ($e->hasResponse()) {
-            throw new SalesforceException(sprintf('Salesforce response error: %s', $e->getResponse()));
+            throw new SalesforceException('Salesforce response error', $e);
         } else {
-            throw new SalesforceException(sprintf('Invalid request: %s', $e->getRequest()));
+            throw new SalesforceException('Invalid request: %s', $e);
         }
     }
 }

--- a/src/Omniphx/Forrest/Exceptions/SalesforceException.php
+++ b/src/Omniphx/Forrest/Exceptions/SalesforceException.php
@@ -2,6 +2,11 @@
 
 namespace Omniphx\Forrest\Exceptions;
 
-class SalesforceException extends \RuntimeException
+use GuzzleHttp\Exception\RequestException;
+
+class SalesforceException extends RequestException
 {
+    public function __construct($message, RequestException $e) {
+        parent::__construct($message, $e->getRequest(), $e->getResponse(), $e);
+    }
 }

--- a/src/Omniphx/Forrest/Exceptions/TokenExpiredException.php
+++ b/src/Omniphx/Forrest/Exceptions/TokenExpiredException.php
@@ -6,4 +6,7 @@ use GuzzleHttp\Exception\RequestException;
 
 class TokenExpiredException extends RequestException
 {
+    public function __construct($message, RequestException $e) {
+        parent::__construct($message, $e->getRequest(), $e->getResponse(), $e);
+    }
 }


### PR DESCRIPTION
Fixing issue #74. Now allows for exception classes to call `$e->getResponse()->getStatusCode()` or `$e->getRequest()->getMethod()`