### PR TITLE
Check for refresh token before storing

### DIFF
--- a/src/Omniphx/Forrest/Authentications/WebServer.php
+++ b/src/Omniphx/Forrest/Authentications/WebServer.php
@@ -126,7 +126,7 @@ class WebServer extends Client implements WebServerInterface
 
         // Encrypt token and store token and in storage.
         $this->storage->putTokenData($jsonResponse);
-        $this->storage->putRefreshToken($jsonResponse['refresh_token']);
+        if(isset($jsonResponse['refresh_token'])) $this->storage->putRefreshToken($jsonResponse['refresh_token']);
 
         // Store resources into the storage.
         $this->storeResources();


### PR DESCRIPTION
Addressing a bug in issue #81 where attempting to store a non-existent refresh token