### PR TITLE
Fixing Lumen Errors/Cleanup

### DIFF
--- a/src/Omniphx/Forrest/Providers/Laravel/ForrestServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/ForrestServiceProvider.php
@@ -4,11 +4,6 @@ namespace Omniphx\Forrest\Providers\Laravel;
 
 use GuzzleHttp\Client;
 use Illuminate\Support\ServiceProvider;
-use Omniphx\Forrest\Providers\Laravel\LaravelEvent;
-use Omniphx\Forrest\Providers\Laravel\LaravelInput;
-use Omniphx\Forrest\Providers\Laravel\LaravelRedirect;
-use Omniphx\Forrest\Providers\Laravel\LaravelCache;
-use Omniphx\Forrest\Providers\Laravel\LaravelSession;
 
 class ForrestServiceProvider extends ServiceProvider
 {
@@ -41,14 +36,14 @@ class ForrestServiceProvider extends ServiceProvider
         $this->app->singleton('forrest', function ($app) {
 
             //Config options:
-            $settings           = config('forrest');
-            $storageType        = config('forrest.storage.type');
+            $settings = config('forrest');
+            $storageType = config('forrest.storage.type');
             $authenticationType = config('forrest.authentication');
 
             //Dependencies:
-            $client   = new Client(['http_errors' => false]);
-            $input    = new LaravelInput();
-            $event    = new LaravelEvent();
+            $client = new Client(['http_errors' => false]);
+            $input = new LaravelInput();
+            $event = new LaravelEvent();
             $redirect = new LaravelRedirect();
 
             //Determine storage dependency:

--- a/src/Omniphx/Forrest/Providers/Laravel/ForrestServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/ForrestServiceProvider.php
@@ -20,11 +20,11 @@ class ForrestServiceProvider extends ServiceProvider
     protected $defer = false;
 
     /**
-     * Register the service provider.
+     * Bootstrap the application events.
      *
      * @return void
      */
-    public function register()
+    public function boot()
     {
         $this->publishes([
             __DIR__.'/../../../../config/config.php' => config_path('forrest.php'),
@@ -32,11 +32,11 @@ class ForrestServiceProvider extends ServiceProvider
     }
 
     /**
-     * Bootstrap the application events.
+     * Register the service provider.
      *
      * @return void
      */
-    public function boot()
+    public function register()
     {
         $this->app->singleton('forrest', function ($app) {
 

--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelStorageProvider.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelStorageProvider.php
@@ -2,8 +2,8 @@
 
 namespace Omniphx\Forrest\Providers\Laravel;
 
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Crypt;
 use Omniphx\Forrest\Exceptions\MissingRefreshTokenException;
 use Omniphx\Forrest\Exceptions\MissingTokenException;
 use Omniphx\Forrest\Interfaces\StorageInterface;
@@ -37,7 +37,7 @@ abstract class LaravelStorageProvider implements StorageInterface
             return Crypt::decrypt($token);
         }
 
-        throw new MissingTokenException(sprintf('No token available in \''. Config::get('forrest.storage.type') .'\' storage'));
+        throw new MissingTokenException(sprintf('No token available in \''.Config::get('forrest.storage.type').'\' storage'));
     }
 
     /**

--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelStorageProvider.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelStorageProvider.php
@@ -2,7 +2,8 @@
 
 namespace Omniphx\Forrest\Providers\Laravel;
 
-use Crypt;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Config;
 use Omniphx\Forrest\Exceptions\MissingRefreshTokenException;
 use Omniphx\Forrest\Exceptions\MissingTokenException;
 use Omniphx\Forrest\Interfaces\StorageInterface;
@@ -36,7 +37,7 @@ abstract class LaravelStorageProvider implements StorageInterface
             return Crypt::decrypt($token);
         }
 
-        throw new MissingTokenException(sprintf('No token available in \''.\Config::get('forrest.storage.type').'\' storage'));
+        throw new MissingTokenException(sprintf('No token available in \''. Config::get('forrest.storage.type') .'\' storage'));
     }
 
     /**

--- a/src/Omniphx/Forrest/Providers/Lumen/ForrestServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/Lumen/ForrestServiceProvider.php
@@ -29,16 +29,6 @@ class ForrestServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../../../config/config.php' => $this->configPath(),
         ]);
-
-        $this->checkForAuthentication();
-    }
-
-    protected function checkForAuthentication()
-    {
-        $authentication = config('forrest.authentication');
-        if (!empty($authentication)) {
-            require_once __DIR__ . "/Routes/{$authentication}.php";
-        }
     }
 
     /**

--- a/src/Omniphx/Forrest/Providers/Lumen/ForrestServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/Lumen/ForrestServiceProvider.php
@@ -20,11 +20,11 @@ class ForrestServiceProvider extends ServiceProvider
     protected $defer = false;
 
     /**
-     * Register the service provider.
+     * Bootstrap the application events.
      *
      * @return void
      */
-    public function register()
+    public function boot()
     {
         $this->publishes([
             __DIR__.'/../../../../config/config.php' => $this->configPath(),
@@ -32,11 +32,11 @@ class ForrestServiceProvider extends ServiceProvider
     }
 
     /**
-     * Bootstrap the application events.
+     * Register the service provider.
      *
      * @return void
      */
-    public function boot()
+    public function register()
     {
         $this->app->singleton('forrest', function ($app) {
 

--- a/src/Omniphx/Forrest/Providers/Lumen/ForrestServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/Lumen/ForrestServiceProvider.php
@@ -4,8 +4,8 @@ namespace Omniphx\Forrest\Providers\Lumen;
 
 use GuzzleHttp\Client;
 use Illuminate\Support\ServiceProvider;
-use Omniphx\Forrest\Providers\Laravel\LaravelEvent;
 use Omniphx\Forrest\Providers\Laravel\LaravelCache;
+use Omniphx\Forrest\Providers\Laravel\LaravelEvent;
 use Omniphx\Forrest\Providers\Laravel\LaravelInput;
 use Omniphx\Forrest\Providers\Laravel\LaravelRedirect;
 use Omniphx\Forrest\Providers\Laravel\LaravelSession;

--- a/src/Omniphx/Forrest/Providers/Lumen/ForrestServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/Lumen/ForrestServiceProvider.php
@@ -5,9 +5,9 @@ namespace Omniphx\Forrest\Providers\Lumen;
 use GuzzleHttp\Client;
 use Illuminate\Support\ServiceProvider;
 use Omniphx\Forrest\Providers\Laravel\LaravelEvent;
+use Omniphx\Forrest\Providers\Laravel\LaravelCache;
 use Omniphx\Forrest\Providers\Laravel\LaravelInput;
 use Omniphx\Forrest\Providers\Laravel\LaravelRedirect;
-use Omniphx\Forrest\Providers\Laravel\LaravelCache;
 use Omniphx\Forrest\Providers\Laravel\LaravelSession;
 
 class ForrestServiceProvider extends ServiceProvider
@@ -41,14 +41,14 @@ class ForrestServiceProvider extends ServiceProvider
         $this->app->singleton('forrest', function ($app) {
 
             //Config options:
-            $settings           = config('forrest');
-            $storageType        = config('forrest.storage.type');
+            $settings = config('forrest');
+            $storageType = config('forrest.storage.type');
             $authenticationType = config('forrest.authentication');
 
             //Dependencies:
-            $client   = new Client();
-            $input    = new LaravelInput();
-            $event    = new LaravelEvent();
+            $client = new Client();
+            $input = new LaravelInput();
+            $event = new LaravelEvent();
             $redirect = new LaravelRedirect();
 
             //Determine storage dependency:


### PR DESCRIPTION
- Removed inline namespaces, added to use imports for readability (Removed from `Laravel\ForrestServiceProvider`, same namespace)
- Added full namespaces for `Crypt` and `Config` in `LaravelStorageProvider` to fix Lumen issue
- Removed check/inclusion for `Lumen\ForrestServiceProvider` for `WebServer` or `UserPassword` Route file (Route directory does not exist for Lumen)

Testing:
- Ran phpspec with no errors
- Symlinked updated repo into personal laravel and lumen projects