### PR TITLE
Added pass by reference prefix to setArgument method, fixes #139

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -709,7 +709,7 @@ abstract class Client
         return $options;
     }
 
-    private function setArgument($argument, $options) {
+    private function setArgument($argument, &$options) {
         if (!isset($argument)) return;
         if (!is_array($argument)) return;
         foreach ($argument as $key => $value) {


### PR DESCRIPTION
Fixes the issue in #139 of arguments not being set in magic calls, for example `Forrest::sobjects(...)`.