### PR TITLE
Ensure the array keys actually exist in setting arguements

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -703,8 +703,12 @@ abstract class Client
         $options = [];
         if (empty($arguments)) return $options;
 
-        $this->setArgument($arguments[0], $options);
-        $this->setArgument($arguments[1], $options);
+        if(!empty($arguments[0])) {
+            $this->setArgument($arguments[0], $options);
+        }
+        if(!empty($arguments[1])) {
+            $this->setArgument($arguments[1], $options);
+        }
 
         return $options;
     }


### PR DESCRIPTION
I've discovered this happens when omitting the second lot of parameters to dynamic method calls, for example `Forrest::sobjects('Account/XXXXX);`