### PR TITLE
Fixes the describe method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 php:
 - 5.6
 - 7.0
-- hhvm
 
 before_script:
 - composer self-update

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -415,18 +415,19 @@ abstract class Client
     /**
      * Describes all global objects available in the organization.
      *
+     * @param string $object_name
      * @param array $options
-     *
      * @return array
      */
-    public function describe($options = [])
+    public function describe($object_name = null, $options = [])
     {
-        $url = $this->getBaseUrl();
-        $url .= '/sobjects';
+        $url = sprintf('%s/sobjects', $this->getBaseUrl());
+        
+        if ( ! empty($object_name)) {
+            $url .= sprintf('/%s/describe', $object_name);
+        }
 
-        $describe = $this->request($url, $options);
-
-        return $describe;
+        return $this->request($url, $options);
     }
 
     /**


### PR DESCRIPTION
The documentation mentions use of the describe method as follows:
```php
Forrest::describe('Account',['format'=>'xml']);
```
However in attempting to use the method I found it wasn't implemented in this manner. This PR corrects the underlying method to work as documented.