### PR TITLE
Pass options by reference so the changes persist

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -688,7 +688,7 @@ abstract class Client
         return $options;
     }
 
-    private function setArgument($argument, $options) {
+    private function setArgument($argument, &$options) {
         if (!is_array($argument)) return;
         foreach ($argument as $key => $value) {
             $options[$key] = $value;


### PR DESCRIPTION
This is a tiny change that resolves a problem I encountered today. Please let me know if I'm completely misguided. I don't have a quick example scenario setup but I can if that would be helpful.

By passing `$options` by value, the options weren't being set elsewhere in the application, so for example POSTing to create a new instance of a sObject would fail because the request would be sent as a GET request. Passing the options array by reference (which appears to be the case in earlier versions of this function) resolved my difficulties immediately.