### PR TITLE
initialize config for lumen

### DIFF
--- a/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
@@ -76,6 +76,10 @@ abstract class BaseServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        if (str_contains($this->app->version(), 'Lumen')) {
+            $this->app->configure('forrest');
+        }
+        
         $this->app->singleton('forrest', function ($app) {
 
             // Config options


### PR DESCRIPTION
Lumen does not autoload configuration files, I have seen this pattern in other libraries.  