### PR TITLE
Made LaravelEvent Provider backwards compatible with Laravel versions less than 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "omniphx/forrest",
+    "name": "yannzeeuwe/forrest",
     "description": "Salesforce / Force.com REST API Client for Laravel 5",
     "license":"MIT",
     "keywords":["salesforce", "laravel", "rest", "force.com", "force"],

--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelEvent.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelEvent.php
@@ -25,6 +25,10 @@ class LaravelEvent implements EventInterface
      */
     public function fire($event, $payload = [], $halt = false)
     {
-        return $this->event->dispatch($event, $payload, $halt);
+        if (method_exists($this->event, 'dispatch')) {
+            return $this->event->dispatch($event, $payload, $halt);
+        }
+
+        return $this->event->fire($event, $payload, $halt);
     }
 }


### PR DESCRIPTION
The current LaravelEvent Provider assumes events are fired by calling the dispatch method on an Event. This only works with Laravel 5.4+

I added a check that determines whether the dispatch method exists. If it doesn it falls back to the fire method.