### PR TITLE
Made the LaravelEvent Provider backwards compatible with Laravel versions less than 5.4

### DIFF
--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelEvent.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelEvent.php
@@ -25,6 +25,10 @@ class LaravelEvent implements EventInterface
      */
     public function fire($event, $payload = [], $halt = false)
     {
-        return $this->event->dispatch($event, $payload, $halt);
+        if (method_exists($this->event, 'dispatch')) {
+            return $this->event->dispatch($event, $payload, $halt);
+        }
+
+        return $this->event->fire($event, $payload, $halt);
     }
 }


### PR DESCRIPTION
Another try, this time without my own composer.json