### PR TITLE
More description message for Salesforce response error

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -788,7 +788,7 @@ abstract class Client
         if ($ex->hasResponse() && $ex->getResponse()->getStatusCode() == 401) {
             throw new TokenExpiredException('Salesforce token has expired', $ex);
         } elseif ($ex->hasResponse()) {
-            throw new SalesforceException('Salesforce response error: '.$ex->getMessage());
+            throw new SalesforceException('Salesforce response error: '.$ex->getMessage(), $ex);
         } else {
             throw new SalesforceException('Invalid request: %s', $ex);
         }

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -788,7 +788,7 @@ abstract class Client
         if ($ex->hasResponse() && $ex->getResponse()->getStatusCode() == 401) {
             throw new TokenExpiredException('Salesforce token has expired', $ex);
         } elseif ($ex->hasResponse()) {
-            throw new SalesforceException('Salesforce response error', $ex);
+            throw new SalesforceException('Salesforce response error: %s', $ex->getMessage());
         } else {
             throw new SalesforceException('Invalid request: %s', $ex);
         }

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -788,7 +788,7 @@ abstract class Client
         if ($ex->hasResponse() && $ex->getResponse()->getStatusCode() == 401) {
             throw new TokenExpiredException('Salesforce token has expired', $ex);
         } elseif ($ex->hasResponse()) {
-            throw new SalesforceException('Salesforce response error: %s', $ex->getMessage());
+            throw new SalesforceException('Salesforce response error: '.$ex->getMessage());
         } else {
             throw new SalesforceException('Invalid request: %s', $ex);
         }


### PR DESCRIPTION
When making API calls, an exception can occur and the only exception through is "Salesforce error". Included the entire message in the exception to make debugging easier.