### PR TITLE
Added UserPasswordSOAP Authentication, and runtime SOAP Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Omniphx\Forrest\Providers\Laravel\ForrestServiceProvider::class
 
 >For Laravel 4, add `Omniphx\Forrest\Providers\Laravel4\ForrestServiceProvider` in `app/config/app.php`. Alias will remain the same.
 
-### Lumen Installation 
+### Lumen Installation
 
 ```php
 class_alias('Omniphx\Forrest\Providers\Laravel\Facades\Forrest', 'Forrest');
@@ -63,7 +63,7 @@ USERNAME=mattjmitchener@gmail.com
 PASSWORD=password123
 ```
 
->For Lumen, you should copy the config file from `src/config/config.php` and add it to a `forrest.php` configuration file under a config directory in the root of your application. 
+>For Lumen, you should copy the config file from `src/config/config.php` and add it to a `forrest.php` configuration file under a config directory in the root of your application.
 
 >For Laravel 4, run `php artisan config:publish omniphx/forrest` which create `app/config/omniphx/forrest/config.php`
 
@@ -118,8 +118,9 @@ Route::get('/authenticate', function()
 
 1. Salesforce allows individual logins via a SOAP Login
 2. The Bearer access token returned from the SOAP login can be used similar to Oauth key
-3. Update your config file with values for `loginURL`, `username`, and `password`.
-With the Username Password flow, you can directly authenticate with the `Forrest::authenticate()` method.
+3. Update your config file and set the `authentication` value to `UserPasswordSoap`
+4. Update your config file with values for `loginURL`, `username`, and `password`.
+With the Username Password SOAP flow, you can directly authenticate with the `Forrest::authenticate()` method.
 
 >To use this authentication you can add your username, and password to the config file. Security token might need to be ammended to your password unless your IP address is whitelisted.
 
@@ -131,7 +132,7 @@ Route::get('/authenticate', function()
 });
 ```
 
-If your application requires logging in to salesforce as different users, you can alternatively pass in the login url, username and password to the authenticateUser call.
+If your application requires logging in to salesforce as different users, you can alternatively pass in the login url, username, and password to the `Forrest::authenticateUser()` method.
 
 >Security token might need to be ammended to your password unless your IP address is whitelisted.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,37 @@ Route::get('/authenticate', function()
     return Redirect::to('/');
 });
 ```
+##### SOAP authentication flow
+(When you cannot create a connected App in Salesforce)
+
+1. Salesforce allows individual logins via a SOAP Login
+2. The Bearer access token returned from the SOAP login can be used similar to Oauth key
+3. Update your config file with values for `loginURL`, `username`, and `password`.
+With the Username Password flow, you can directly authenticate with the `Forrest::authenticate()` method.
+
+>To use this authentication you can add your username, and password to the config file. Security token might need to be ammended to your password unless your IP address is whitelisted.
+
+```php
+Route::get('/authenticate', function()
+{
+    Forrest::authenticate();
+    return Redirect::to('/');
+});
+```
+
+If your application requires logging in to salesforce as different users, you can alternatively pass in the login url, username and password to the authenticateUser call.
+
+>Security token might need to be ammended to your password unless your IP address is whitelisted.
+
+```php
+Route::Post('/authenticate', function(Request $request)
+{
+    Forrest::authenticateUser('https://login.salesforce.com',$request->username, $request->password);
+    return Redirect::to('/');
+});
+```
+
+
 
 #### Custom login urls
 Sometimes users will need to connect to a sandbox or custom url. To do this, simply pass the url as an argument for the authenticatation method:

--- a/spec/Omniphx/Forrest/Authentications/UserPasswordSoapSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/UserPasswordSoapSpec.php
@@ -1,0 +1,741 @@
+<?php
+
+namespace spec\Omniphx\Forrest\Authentications;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Omniphx\Forrest\Exceptions\TokenExpiredException;
+use Omniphx\Forrest\Interfaces\EncryptorInterface;
+use Omniphx\Forrest\Interfaces\EventInterface;
+use Omniphx\Forrest\Interfaces\InputInterface;
+use Omniphx\Forrest\Interfaces\RedirectInterface;
+use Omniphx\Forrest\Interfaces\FormatterInterface;
+use Omniphx\Forrest\Interfaces\RepositoryInterface;
+use Omniphx\Forrest\Interfaces\ResourceRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class UserPasswordSoapSpec extends ObjectBehavior
+{
+    protected $versionJSON = '[
+        {
+            "label": "Spring 15",
+            "url": "/services/data/v33.0",
+            "version": "33.0"
+        },
+        {
+            "label": "Summer 15",
+            "url": "/services/data/v34.0",
+            "version": "34.0"
+        },
+        {
+            "label": "Winter 16",
+            "url": "/services/data/v35.0",
+            "version": "35.0"
+        }
+    ]';
+
+    protected $versionArray = [
+        [
+            "label"   => "Spring 15",
+            "url"     => "/services/data/v33.0",
+            "version" => "33.0"
+        ],
+        [
+            "label"   => "Summer 15",
+            "url"     => "/services/data/v34.0",
+            "version" => "34.0"
+        ],
+        [
+            "label"   => "Winter 16",
+            "url"     => "/services/data/v35.0",
+            "version" => "35.0"
+        ]
+    ];
+
+    protected $token = [
+        "signature" => "SOAPHasNoSecretSig",
+        "id" => "https://login.salesforce.com/id/00Do0000000xxxxx/005o0000000xxxxx",
+        "access_token" => "00Do0000000secret",
+        "token_type" => "Bearer",
+        "instance_url" => "https://instance.salesforce.com"
+        ];
+
+    protected $authenticationJSON = [
+        "signature" => "SOAPHasNoSecretSig",
+        "id" => "https://login.salesforce.com/id/00Do0000000xxxxx/005o0000000xxxxx",
+        "access_token" => "00Do0000000secret",
+        "token_type" => "Bearer",
+        "instance_url" => "https://instance.salesforce.com"
+        ];
+
+    protected $failedAuthenticationXML = '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sf="urn:fault.partner.soap.sforce.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><soapenv:Fault><faultcode>sf:INVALID_LOGIN</faultcode><faultstring>INVALID_LOGIN: Invalid username, password, security token; or user locked out.</faultstring><detail><sf:LoginFault xsi:type="sf:LoginFault"><sf:exceptionCode>INVALID_LOGIN</sf:exceptionCode><sf:exceptionMessage>Invalid username, password, security token; or user locked out.</sf:exceptionMessage></sf:LoginFault></detail></soapenv:Fault></soapenv:Body></soapenv:Envelope>';
+
+    protected $authenticationXML = '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="urn:partner.soap.sforce.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><loginResponse><result><metadataServerUrl>https://instance.salesforce.com/services/Soap/m/46.0/00000000000uXgY</metadataServerUrl><passwordExpired>false</passwordExpired><sandbox>false</sandbox><serverUrl>https://instance.salesforce.com/services/Soap/u/46.0/00D36000000uXgY</serverUrl><sessionId>00Do0000000secret</sessionId><userId>005o0000000xxxxx</userId><userInfo><accessibilityMode>false</accessibilityMode><currencySymbol>$</currencySymbol><orgAttachmentFileSizeLimit>5242880</orgAttachmentFileSizeLimit><orgDefaultCurrencyIsoCode>USD</orgDefaultCurrencyIsoCode><orgDisallowHtmlAttachments>false</orgDisallowHtmlAttachments><orgHasPersonAccounts>false</orgHasPersonAccounts><organizationId>00Do0000000xxxxx</organizationId><organizationMultiCurrency>false</organizationMultiCurrency><organizationName>The Organization Name</organizationName><profileId>00000000000000CAA4</profileId><roleId>00E36000000000000C</roleId><sessionSecondsValid>7200</sessionSecondsValid><userDefaultCurrencyIsoCode xsi:nil="true"/><userEmail>user@email.com</userEmail><userFullName>John Doe</userFullName><userId>005o0000000xxxxx</userId><userLanguage>en_US</userLanguage><userLocale>en_US</userLocale><userName>user@email.com</userName><userTimeZone>Pacific/Honolulu</userTimeZone><userType>Standard</userType><userUiSkin>Theme3</userUiSkin></userInfo></result></loginResponse></soapenv:Body></soapenv:Envelope>';
+
+    protected $responseXML = '
+        <meseek>
+            <intro>I\'m Mr. Meseeks, look at me!</intro>
+            <problem>Get 2 strokes off Gary\'s golf swing</problem>
+            <solution>Have you tried squring your shoulders, Gary?</solution>
+        </meseek>';
+
+    protected $decodedResponse = ['foo' => 'bar'];
+
+    protected $settings = [
+        'authenticationFlow' => 'UserPasswordSoap',
+        'credentials' => [
+            'consumerKey'    => 'testingClientId',
+            'consumerSecret' => 'testingClientSecret',
+            'callbackURI'    => 'callbackURL',
+            'loginURL'       => 'https://login.salesforce.com',
+            'username'       => 'user@email.com',
+            'password'       => 'mypassword',
+        ],
+        'parameters' => [
+            'display'   => 'popup',
+            'immediate' => 'false',
+            'state'     => '',
+            'scope'     => '',
+        ],
+        'instanceURL' => '',
+        'authRedirect' => 'redirectURL',
+        'version' => '30.0',
+        'defaults' => [
+            'method'          => 'get',
+            'format'          => 'json',
+            'compression'     => false,
+            'compressionType' => 'gzip',
+        ],
+        'language' => 'en_US',
+    ];
+
+    public function let(
+        ClientInterface $mockedHttpClient,
+        EncryptorInterface $mockedEncryptor,
+        EventInterface $mockedEvent,
+        InputInterface $mockedInput,
+        RedirectInterface $mockedRedirect,
+        ResponseInterface $mockedResponse,
+        RepositoryInterface $mockedInstanceURLRepo,
+        RepositoryInterface $mockedRefreshTokenRepo,
+        ResourceRepositoryInterface $mockedResourceRepo,
+        RepositoryInterface $mockedStateRepo,
+        RepositoryInterface $mockedTokenRepo,
+        RepositoryInterface $mockedVersionRepo,
+        FormatterInterface $mockedFormatter)
+    {
+        $this->beConstructedWith(
+            $mockedHttpClient,
+            $mockedEncryptor,
+            $mockedEvent,
+            $mockedInput,
+            $mockedRedirect,
+            $mockedInstanceURLRepo,
+            $mockedRefreshTokenRepo,
+            $mockedResourceRepo,
+            $mockedStateRepo,
+            $mockedTokenRepo,
+            $mockedVersionRepo,
+            $mockedFormatter,
+            $this->settings);
+
+        $mockedInstanceURLRepo->get()->willReturn('https://instance.salesforce.com');
+
+        $mockedResourceRepo->get(Argument::any())->willReturn('/services/data/v30.0/resource');
+        $mockedResourceRepo->put(Argument::any())->willReturn(null);
+
+        $mockedTokenRepo->get()->willReturn($this->token);
+        $mockedTokenRepo->put($this->token)->willReturn(null);
+
+        $mockedFormatter->setBody(Argument::any())->willReturn(null);
+        $mockedFormatter->setHeaders()->willReturn([
+            'Authorization' => 'Bearer accessToken',
+            'Accept'        => 'application/json',
+            'Content-Type'  => 'application/json',
+        ]);
+
+        $mockedVersionRepo->get()->willReturn(['url' => '/resources']);
+
+        $mockedFormatter->formatResponse($mockedResponse)->willReturn(['foo' => 'bar']);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType('Omniphx\Forrest\Authentications\UserPasswordSoap');
+    }
+
+    public function it_should_authenticate(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        ResponseInterface $mockedVersionRepo,
+        FormatterInterface $mockedFormatter,
+        ResponseInterface $versionResponse)
+    {
+        $mockedHttpClient->request(
+            'post',
+            'url/services/Soap/u/46.0',
+            ["http_errors" => false,
+                "headers" =>
+                    ["Content-Type" => "text/xml; charset=UTF-8",
+                    "SOAPAction" => "login"],
+                "body" => '<?xml version="1.0" encoding="utf-8" ?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><n1:login xmlns:n1="urn:partner.soap.sforce.com"><n1:username>user@email.com</n1:username><n1:password>mypassword</n1:password></n1:login></env:Body></env:Envelope>'])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedHttpClient->request(
+            'get',
+            'https://instance.salesforce.com/resources',
+            ['headers' => [
+                'Authorization' => 'Bearer accessToken',
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json'
+            ]])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedResponse->getBody()->shouldBeCalled()->willReturn($this->authenticationXML);
+
+        $mockedHttpClient->request(
+            'get',
+            'https://instance.salesforce.com/services/data',
+            ['headers' => [
+                'Authorization' => 'Bearer accessToken',
+                'Accept'        => 'application/json',
+                'Content-Type'  => 'application/json'
+            ]])
+            ->shouldBeCalled()
+            ->willReturn($versionResponse);
+
+        $mockedFormatter->formatResponse($versionResponse)->shouldBeCalled()->willReturn($this->versionArray);
+
+        $mockedVersionRepo->has()->willReturn(false);
+        $mockedVersionRepo->put(["label" => "Winter 16", "url" => "/services/data/v35.0", "version" => "35.0"])->shouldBeCalled();
+
+        $this->authenticate('url')->shouldReturn(null);
+
+    }
+
+    public function it_should_return_the_request(
+        ClientInterface $mockedHttpClient,
+        RequestInterface $mockedRequest,
+        ResponseInterface $mockedResponse)
+    {
+        $mockedHttpClient->request(
+            'get',
+            'url',
+            ['headers' => [
+                'Authorization' => 'Bearer accessToken',
+                'Accept'        => 'application/json',
+                'Content-Type'  => 'application/json']])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $this->request('url', ['key' => 'value'])->shouldReturn(['foo' => 'bar']);
+    }
+
+    /*
+     *
+     * Specs below are for the parent class.
+     *
+     */
+
+    public function it_should_return_all_versions(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('get', 'https://instance.salesforce.com/services/data', ['headers' => ['Authorization' => 'Bearer accessToken', 'Accept' => 'application/json', 'Content-Type' => 'application/json']])->shouldBeCalled()->willReturn($mockedResponse);
+
+        $versionArray = json_decode($this->versionJSON, true);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($versionArray);
+
+        $this->versions()->shouldReturn($versionArray);
+    }
+
+    public function it_should_return_resources(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('get', 'https://instance.salesforce.com/resources', ['headers' => ['Authorization' => 'Bearer accessToken', 'Accept' => 'application/json', 'Content-Type' => 'application/json']])->shouldBeCalled()->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->resources()->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_identity(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://login.salesforce.com/id/00Do0000000xxxxx/005o0000000xxxxx',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->identity()->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_limits(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/resources/limits',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->limits()->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_describe(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/resources/sobjects',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->describe()->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_query(
+       ClientInterface $mockedHttpClient,
+       ResponseInterface $mockedResponse,
+       FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/data/v30.0/resource?q=query',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->query('query')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_query_next(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/next',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->next('/next')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_queryExplain(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/data/v30.0/resource?explain=queryExplain',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->queryExplain('queryExplain')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_queryAll(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/data/v30.0/resource?q=queryAll',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->queryAll('queryAll')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_quick_actions(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/data/v30.0/resource',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->quickActions()->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_search(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/data/v30.0/resource?q=search',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->search('search')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_ScopeOrder(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/data/v30.0/resource/scopeOrder',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->scopeOrder()->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_search_layouts(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/data/v30.0/resource/layout/?q=objectList',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->searchLayouts('objectList')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_suggested_articles(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/data/v30.0/resource/suggestTitleMatches?q=suggestedArticles',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->suggestedArticles('suggestedArticles')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_suggested_queries(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/data/v30.0/resource/suggestSearchQueries?q=suggested',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->suggestedQueries('suggested')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_return_custom_request(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'https://instance.salesforce.com/services/apexrest/FieldCase?foo=bar',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->custom('/FieldCase', ['parameters' => ['foo' => 'bar']])
+            ->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_returns_a_json_resource(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'uri',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->request('uri', [])->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_returns_a_xml_resource(
+        ClientInterface $mockedHttpClient,
+        RequestInterface $mockedRequest,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient
+            ->request('get',
+                'uri',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $decodedXML = simplexml_load_string($this->responseXML);
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($decodedXML);
+
+        $this->request('uri', ['format' => 'xml'])->shouldReturnAnInstanceOf('SimpleXMLElement');
+    }
+
+    public function it_should_format_header(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('get',
+            'uri',
+            [
+                'headers' => [
+                    'Authorization' => 'Bearer accessToken',
+                    'Accept'        => 'application/json',
+                    'Content-Type'  => 'application/json',
+                ]
+            ])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->request('uri', ['compression' => false])->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_format_header_in_url_encoding(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('get',
+            'uri',
+            [
+                'headers' => [
+                    'Authorization' => 'bearer accessToken',
+                    'Accept'        => 'application/x-www-form-urlencoded',
+                    'Content-Type'  => 'application/x-www-form-urlencoded',
+                ]
+            ])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->setHeaders()->shouldBeCalled()->willReturn([
+            'Authorization' => 'bearer accessToken',
+            'Accept'        => 'application/x-www-form-urlencoded',
+            'Content-Type'  => 'application/x-www-form-urlencoded',
+        ]);
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn('rawresponse');
+
+        $this->request('uri', ['format' => 'urlencoded'])->shouldReturn('rawresponse');
+    }
+
+    public function it_should_format_header_with_gzip(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('get',
+            'uri',
+            [
+                'headers' => [
+                    'Authorization'    => 'bearer accessToken',
+                    'Accept'           => 'application/json',
+                    'Content-Type'     => 'application/json',
+                    'Accept-Encoding'  => 'gzip',
+                    'Content-Encoding' => 'gzip',
+                ]
+            ])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+
+        $mockedFormatter->setHeaders()->shouldBeCalled()->willReturn([
+            'Authorization'    => 'bearer accessToken',
+            'Accept'           => 'application/json',
+            'Content-Type'     => 'application/json',
+            'Accept-Encoding'  => 'gzip',
+            'Content-Encoding' => 'gzip',
+        ]);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->request('uri', ['compression' => true, 'compressionType' => 'gzip'])->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_format_header_with_deflate(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('get',
+            'uri',
+            [
+                'headers' => [
+                    'Authorization'    => 'bearer accessToken',
+                    'Accept'           => 'application/json',
+                    'Content-Type'     => 'application/json',
+                    'Accept-Encoding'  => 'deflate',
+                    'Content-Encoding' => 'deflate',
+                ]
+            ])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->setHeaders()->shouldBeCalled()->willReturn([
+            'Authorization'    => 'bearer accessToken',
+            'Accept'           => 'application/json',
+            'Content-Type'     => 'application/json',
+            'Accept-Encoding'  => 'deflate',
+            'Content-Encoding' => 'deflate',
+        ]);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->request('uri', ['compression' => true, 'compressionType' => 'deflate'])->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_allows_access_to_the_guzzle_client(ClientInterface $mockedHttpClient)
+    {
+        $this->getClient()->shouldReturn($mockedHttpClient);
+    }
+
+    public function it_should_allow_a_get_request(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('GET', Argument::any(), Argument::any())->willReturn($mockedResponse);
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+        $this->get('uri')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_allow_a_post_request(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('POST', Argument::any(), Argument::any())->willReturn($mockedResponse);
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+        $this->post('uri', ['test' => 'param'])->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_allow_a_put_request(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('PUT', Argument::any(), Argument::any())->willReturn($mockedResponse);
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+        $this->put('uri', ['test' => 'param'])->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_allow_a_patch_request(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+        $mockedHttpClient->request('PATCH', Argument::any(), Argument::any())->willReturn($mockedResponse);
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+        $this->patch('uri', ['test' => 'param'])->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_allow_a_head_request(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter
+    ) {
+        $mockedHttpClient->request('HEAD', Argument::any(), Argument::any())->willReturn($mockedResponse);
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->head('url')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_allow_a_delete_request(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter
+    ) {
+        $mockedHttpClient->request('DELETE', Argument::any(), Argument::any())->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->decodedResponse);
+
+        $this->delete('url')->shouldReturn($this->decodedResponse);
+    }
+
+    public function it_should_fire_a_response_event(
+        ClientInterface $mockedHttpClient,
+        EventInterface $mockedEvent,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter
+    ) {
+        $mockedHttpClient->request(Argument::any(), Argument::any(), Argument::any())->willReturn($mockedResponse);
+        $mockedEvent->fire('forrest.response', Argument::any())->shouldBeCalled();
+
+        $this->versions();
+    }
+}

--- a/src/Omniphx/Forrest/Authentications/UserPassword.php
+++ b/src/Omniphx/Forrest/Authentications/UserPassword.php
@@ -4,13 +4,12 @@ namespace Omniphx\Forrest\Authentications;
 
 use Omniphx\Forrest\Client as BaseAuthentication;
 use Omniphx\Forrest\Interfaces\UserPasswordInterface;
-use Psr\Http\Message\ResponseInterface;
 
 class UserPassword extends BaseAuthentication implements UserPasswordInterface
 {
     public function authenticate($url = null)
     {
-        $loginURL = $url === null ? $this->credentials['loginURL'] : $url;
+        $loginURL = null === $url ? $this->credentials['loginURL'] : $url;
         $loginURL .= '/services/oauth2/token';
 
         $authToken = $this->getAuthToken($loginURL);

--- a/src/Omniphx/Forrest/Authentications/UserPasswordSoap.php
+++ b/src/Omniphx/Forrest/Authentications/UserPasswordSoap.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Omniphx\Forrest\Authentications;
+
+use Omniphx\Forrest\Client as BaseAuthentication;
+use Omniphx\Forrest\Interfaces\UserPasswordSoapInterface;
+
+class UserPasswordSoap extends BaseAuthentication implements UserPasswordSoapInterface
+{
+    public function authenticate($url = null)
+    {
+        $loginURL = null === $url ? $this->credentials['loginURL'] : $url;
+        $this->authenticateUser($loginURL);
+    }
+
+    public function authenticateUser($url = null, $username = null, $password = null)
+    {
+        $loginURL = null === $url ? $this->credentials['loginURL'] : $url;
+        $loginURL .= '/services/Soap/u/46.0';
+
+        $loginUser = null === $username ? $this->credentials['username'] : $username;
+        $loginPassword = null === $password ? $this->credentials['password'] : $password;
+        $this->credentials['username'] = $loginUser;
+        $this->credentials['password'] = $loginPassword;
+        $authToken = $this->getAuthUser($loginURL, $loginUser, $loginPassword);
+        $this->tokenRepo->put($authToken);
+
+        $this->storeVersion();
+        $this->storeResources();
+    }
+
+    /**
+     * Refresh authentication token by re-authenticating.
+     *
+     * @return mixed $response
+     */
+    public function refresh()
+    {
+        return $this->authenticate();
+        /* Per the SOAP Documenetationthe token life is extended at every call,
+         * so the refresh is not needed. Token will expire in two hours from
+         * last call by default.
+         */
+    }
+
+    /**
+     * @param string $tokenURL
+     * @param string $username
+     * @param string $password
+     *
+     * @return string
+     */
+    private function getAuthUser($url, $username, $password)
+    {
+        /******************************************************************
+        SOAP Login method - Does not require a connected/defined application
+        https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_login.htm
+        ******************************************************************/
+
+        // Required to avoid a 500 error on invalid login and guzzle unhandled error
+        $parameters['http_errors'] = false;
+
+        $parameters['headers'] = [
+            'Content-Type' => 'text/xml; charset=UTF-8',
+            'SOAPAction' => 'login',
+        ];
+
+        /* Create a SOAP envelope containing the username and password
+         *  and put the resulting SOAP message in the POST Body.
+         */
+        $parameters['body'] = '<?xml version="1.0" encoding="utf-8" ?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><n1:login xmlns:n1="urn:partner.soap.sforce.com"><n1:username>'.$username.'</n1:username><n1:password>'.$password.'</n1:password></n1:login></env:Body></env:Envelope>';
+
+        $response = $this->httpClient->request('post', $url, $parameters);
+        $xmlResponseBody = $response->getBody();
+        $authTokenDecoded = $this->convertSoapToJSON($xmlResponseBody);
+        $this->handleAuthenticationErrors($authTokenDecoded);
+
+        return $authTokenDecoded;
+    }
+
+    /**
+     * Revokes access token from Salesforce. Will not flush token from storage.
+     *
+     * @return mixed
+     */
+    public function revoke()
+    {
+        /*
+        Session Expiration
+        Client apps aren’t required to explicitly log out to end a session. Sessions expire automatically after a predetermined length of inactivity. The default is two hours. If you make an API call, the inactivity timer is reset to zero. To change the session expiration (timeout) value, from Setup, enter Session Settings in the Quick Find box, and select Session Settings.
+
+        Another thread states that the session keys are unique to a user, so for example
+        a background task issuing logout has the ability to kill a web session.
+
+        Here is the gist of it. When you make an API call to Salesforce, the they authenticate the calls by examining the SOAP header that contains a session key. Session keys are allocated on a per-user basis. What this means is that if you create two connections at the same time (i.e. using login() from two different threads) - they will both be using the same session key.
+
+        Decision:  Dont invoke any type of logout/revoke method.  Protect your session keys!
+        */
+    }
+
+    protected function extractToken($response)
+    {
+        $sessionId = $response->sessionId;
+        $serverUrl = $response->serverUrl;
+    }
+
+    protected function convertSoapToJSON($response)
+    {
+        // make the result look like standard xml instead of SOAP
+        // handle the result from a SOAP Fault the same as a regular result.
+        if (false === strpos($response, '<soapenv:Fault>')) {
+            $posResult1 = strpos($response, '<result>');
+            $posResult2 = strpos($response, '</result>');
+            $len = 9;
+        } else {
+            $posResult1 = strpos($response, '<soapenv:Fault>');
+            $posResult2 = strpos($response, '</soapenv:Fault>');
+            $len = 16;
+        }
+
+        // Start building a simple XML String
+        $result = '<?xml version="1.0" encoding="UTF-8"?>'.substr($response, $posResult1, ($posResult2 - $posResult1 + $len));
+
+        // replace namespaces
+        $result = preg_replace("/(<\/?)(\w+):([^>]*>)/", '$1$2$3', $result);
+        $result = str_replace('xsi:', '', $result);
+
+        // Disable libxml errors to fetch error information as needed
+        libxml_use_internal_errors(true);
+
+        // Convert the XML to a standard object via JSON intermediary.
+        $xml = simplexml_load_string($result);
+        $json = json_encode($xml);
+        $data = json_decode($json);
+
+        // Create an empty response Object, then pick and choose items to insert from XML,
+        $tokenResponse = [];
+        $tokenResponse['signature'] = "SOAPHasNoSecretSig";
+        // $tokenResponse['issued_at'] = time(); // including this causes phpspec to fail
+
+        // Handle errors from Login
+        if (array_key_exists('faultcode', $data)) {
+            // Forrest is looking for error
+            $tokenResponse['error'] = $data->faultcode;
+        }
+        if (array_key_exists('faultstring', $data)) {
+            // Forrest is looking for error_description
+            $tokenResponse['error_description'] = $data->faultstring;
+        }
+
+        // Handle successful SOAP login
+        if (array_key_exists('userId', $data)) {
+            // Forrest is looking for id.  SOAP doesnt return this, so build it
+            // based on well known format.
+            // https://login.salesforce.com/id/<organizationId>/<userId>
+            if($data->sandbox == "false") {
+                $base = "https://login.salesforce.com";
+            }
+            else {
+                $base = "https://test.salesforce.com";
+            }
+            $tokenResponse['id'] = $base."/id/".$data->userInfo->organizationId."/".$data->userId;
+        }
+        // The SOAP session id is what you put in the REST calls header
+        // as "Authorization: Bearer <access_token>"
+        if (array_key_exists('sessionId', $data)) {
+            // Forrest is looking for access_token
+            $tokenResponse['access_token'] = $data->sessionId;
+            $tokenResponse['token_type'] = 'Bearer';
+        }
+        if (array_key_exists('serverUrl', $data)) {
+            // Forrest is looking for instance_url
+            // Extract the base URI
+            $servicesPosition = strpos($data->serverUrl, '/services');
+            $url = substr($data->serverUrl, 0, $servicesPosition);
+            $tokenResponse['instance_url'] = $url;
+        }
+        return $tokenResponse;
+    }
+}

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -364,7 +364,6 @@ abstract class Client
      */
     public function identity($options = [])
     {
-        //$url = $this->resourceRepo->get('identity');
         $token = $this->tokenRepo->get();
         $url = $token['id'];
         $accessToken = $token['access_token'];

--- a/src/Omniphx/Forrest/Interfaces/UserPasswordSoapInterface.php
+++ b/src/Omniphx/Forrest/Interfaces/UserPasswordSoapInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Omniphx\Forrest\Interfaces;
+
+interface UserPasswordSoapInterface extends AuthenticationInterface
+{
+    /**
+     * Begin specific user authentication process.
+     *
+     * @param string $url
+     * @param string $username,$password
+     * @param string $password
+     *
+     * @return mixed
+     */
+    public function authenticateUser($url, $username, $password);
+}

--- a/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
@@ -133,6 +133,22 @@ abstract class BaseServiceProvider extends ServiceProvider
                         $formatter,
                         $settings);
                     break;
+                case 'UserPasswordSoap':
+                    $forrest = new UserPasswordSoap(
+                        $httpClient,
+                        $encryptor,
+                        $event,
+                        $input,
+                        $redirect,
+                        $instanceURLRepo,
+                        $refreshTokenRepo,
+                        $resourceRepo,
+                        $stateRepo,
+                        $tokenRepo,
+                        $versionRepo,
+                        $formatter,
+                        $settings);
+                    break;
                 default:
                     $forrest = new WebServer(
                         $httpClient,

--- a/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Client;
 use Illuminate\Support\ServiceProvider;
 use Omniphx\Forrest\Authentications\WebServer;
 use Omniphx\Forrest\Authentications\UserPassword;
-use Omniphx\Forrest\Providers\Laravel\LaravelCache;
+use Omniphx\Forrest\Authentications\UserPasswordSoap;
 use Omniphx\Forrest\Providers\Laravel\LaravelEvent;
 use Omniphx\Forrest\Providers\Laravel\LaravelEncryptor;
 use Omniphx\Forrest\Providers\Laravel\LaravelInput;
@@ -42,27 +42,27 @@ abstract class BaseServiceProvider extends ServiceProvider
     abstract protected function getConfigPath();
 
     /**
-     * Returns client implementation
+     * Returns client implementation.
      *
      * @return GuzzleHttp\Client
      */
-    protected abstract function getClient();
+    abstract protected function getClient();
 
     /**
-     * Returns client implementation
+     * Returns client implementation.
      *
      * @return GuzzleHttp\Client
      */
-    protected abstract function getRedirect();
+    abstract protected function getRedirect();
 
     /**
      * Bootstrap the application events.
-     *
-     * @return void
      */
     public function boot()
     {
-        if (!method_exists($this, 'getConfigPath')) return;
+        if (!method_exists($this, 'getConfigPath')) {
+            return;
+        }
 
         $this->publishes([
             __DIR__.'/../../../config/config.php' => $this->getConfigPath(),

--- a/src/Omniphx/Forrest/Repositories/InstanceURLRepository.php
+++ b/src/Omniphx/Forrest/Repositories/InstanceURLRepository.php
@@ -4,30 +4,43 @@ namespace Omniphx\Forrest\Repositories;
 
 use Omniphx\Forrest\Interfaces\RepositoryInterface;
 
-class InstanceURLRepository implements RepositoryInterface {
-
+class InstanceURLRepository implements RepositoryInterface
+{
     protected $tokenRepo;
     protected $settings;
 
-    public function __construct(RepositoryInterface $tokenRepo, $settings) {
+    public function __construct(RepositoryInterface $tokenRepo, $settings)
+    {
         $this->tokenRepo = $tokenRepo;
-        $this->settings  = $settings;
+        $this->settings = $settings;
     }
 
-    public function put($instanceURL) {
+    /**
+     * Store the instance URL.
+     *
+     * @parameter $instanceURL   Override the instance URL returned from authentication
+     */
+    public function put($instanceURL)
+    {
         $token = $this->tokenRepo->get();
         $token['instance_url'] = $instanceURL;
         $this->tokenRepo->put($token);
     }
 
-    public function has() {
+    /**
+     * Is there a Token Repo?
+     *
+     * @return bool
+     */
+    public function has()
+    {
         return $this->tokenRepo->has();
     }
 
     /**
-     * Get version
+     * Get Instance URL.
      *
-     * @return mixed
+     * @return string
      */
     public function get()
     {
@@ -36,5 +49,5 @@ class InstanceURLRepository implements RepositoryInterface {
         } else {
             return $this->tokenRepo->get()['instance_url'];
         }
-    } 
+    }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -4,15 +4,14 @@
  * Configuration options for Salesforce Oath settings and REST API defaults.
  */
 return [
-
     /*
-     * Options include WebServer or UserPassword
+     * Options include WebServer, UserPassword, and UserPasswordSoap
      */
     'authentication' => 'WebServer',
 
     /*
      * Enter your credentials
-     * Username and Password are only necessary for UserPassword flow.
+     * Username and Password are only necessary for UserPassword & UserPasswordSoap flows.
      * Likewise, callbackURI is only necessary for WebServer flow.
      */
     'credentials'    => [


### PR DESCRIPTION
I added a new authentication method UserPasswordSoap which behaves like the UserPassword authentication method, but the actual authenticate process makes a SOAP call.  The session id that is returned can be used just like the Oauth token, except the authorization header is Bearer <token> instead of Oauth <token>.   Additionally this method supports the main reason I needed to dive in and add to this project.  I required the ability to login to salesforce on behalf of a user who supplies their credentials.  The salesforce app owner did not understand the Oauth process, and was hesitant on going down that route.   Another bug I saw was in the identity area of the Client, and the Oauth header was hardcoded.  I made it use the token_type as stored in the TokenRepo.     I did my best to recreate the phpspec test for the new authorization type, but that is all new to me.   I've only ever contributed a small fix to something once; this is the first time i've done any major surgery ;)