### PR TITLE
Priority to config version

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -735,8 +735,8 @@ abstract class Client
     {
         $versions = $this->versions();
 
-        $this->storeConfiguredVersion($versions);
         $this->storeLatestVersion($versions);
+        $this->storeConfiguredVersion($versions);
     }
 
     private function storeConfiguredVersion($versions)


### PR DESCRIPTION
If we store the config version and then the latest version, the config version will be overwritten so the config version has no effect.
With this update, the latest version is stored and then (if it is configured) the config version is stored so it has more priority.
The ideal is to store the latest version only if the config is not stored (it could be returning a bool in storeConfiguredVersion and checking it in storeVersion),