### PR TITLE
Support Laravel Service Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Next run `composer update` from the command line to install the package.
 
 ### Laravel Installation
 
-Add the service provider and alias to your `config/app.php` file:
+The package will automatically register the service provider and `Forrest` alias for Laravel `>=5.5`. For earlier versions, add the service provider and alias to your `config/app.php` file:
 
 ```php
 Omniphx\Forrest\Providers\Laravel\ForrestServiceProvider::class

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,15 @@
             "Omniphx\\Forrest\\": "src/Omniphx/Forrest/"
         }
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Omniphx\\Forrest\\Providers\\Laravel\\ForrestServiceProvider"
+            ],
+            "aliases": {
+                "Forrest": "Omniphx\\Forrest\\Providers\\Laravel\\Facades\\Forrest"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Provides support for Laravel's [Package Discovery](https://laravel.com/docs/6.x/packages#package-discovery) for Laravel `>=5.5`.