### PR TITLE
Add support for none format

### DIFF
--- a/spec/Omniphx/Forrest/Authentications/UserPasswordSoapSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/UserPasswordSoapSpec.php
@@ -84,6 +84,8 @@ class UserPasswordSoapSpec extends ObjectBehavior
             <solution>Have you tried squring your shoulders, Gary?</solution>
         </meseek>';
 
+    protected $responseNone = 'A non formatted response';
+
     protected $decodedResponse = ['foo' => 'bar'];
 
     protected $settings = [
@@ -544,6 +546,27 @@ class UserPasswordSoapSpec extends ObjectBehavior
         $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($decodedXML);
 
         $this->request('uri', ['format' => 'xml'])->shouldReturnAnInstanceOf('SimpleXMLElement');
+    }
+
+    public function it_returns_an_unformatted_resource(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+
+        $mockedResponse->getBody()->shouldBeCalled()->willReturn($this->responseNone);
+
+        $mockedHttpClient
+            ->request('get',
+                'uri',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->responseNone);
+
+        $this->request('uri', ['format' => 'none'])->shouldReturn($this->responseNone);
+
     }
 
     public function it_should_format_header(

--- a/spec/Omniphx/Forrest/Authentications/UserPasswordSoapSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/UserPasswordSoapSpec.php
@@ -529,10 +529,8 @@ class UserPasswordSoapSpec extends ObjectBehavior
 
     public function it_returns_a_xml_resource(
         ClientInterface $mockedHttpClient,
-        ResponseInterface $mockedResponse,
-        FormatterInterface $mockedFormatter)
+        ResponseInterface $mockedResponse)
     {
-
         $mockedResponse->getBody()->shouldBeCalled()->willReturn($this->responseXML);
 
         $mockedHttpClient
@@ -542,18 +540,13 @@ class UserPasswordSoapSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($mockedResponse);
 
-        $decodedXML = simplexml_load_string($this->responseXML);
-        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($decodedXML);
-
         $this->request('uri', ['format' => 'xml'])->shouldReturnAnInstanceOf('SimpleXMLElement');
     }
 
     public function it_returns_an_unformatted_resource(
         ClientInterface $mockedHttpClient,
-        ResponseInterface $mockedResponse,
-        FormatterInterface $mockedFormatter)
+        ResponseInterface $mockedResponse)
     {
-
         $mockedResponse->getBody()->shouldBeCalled()->willReturn($this->responseNone);
 
         $mockedHttpClient
@@ -563,10 +556,7 @@ class UserPasswordSoapSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($mockedResponse);
 
-        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->responseNone);
-
         $this->request('uri', ['format' => 'none'])->shouldReturn($this->responseNone);
-
     }
 
     public function it_should_format_header(

--- a/spec/Omniphx/Forrest/Authentications/UserPasswordSoapSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/UserPasswordSoapSpec.php
@@ -527,10 +527,12 @@ class UserPasswordSoapSpec extends ObjectBehavior
 
     public function it_returns_a_xml_resource(
         ClientInterface $mockedHttpClient,
-        RequestInterface $mockedRequest,
         ResponseInterface $mockedResponse,
         FormatterInterface $mockedFormatter)
     {
+
+        $mockedResponse->getBody()->shouldBeCalled()->willReturn($this->responseXML);
+
         $mockedHttpClient
             ->request('get',
                 'uri',

--- a/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
@@ -592,10 +592,12 @@ class UserPasswordSpec extends ObjectBehavior
 
     public function it_returns_a_xml_resource(
         ClientInterface $mockedHttpClient,
-        RequestInterface $mockedRequest,
         ResponseInterface $mockedResponse,
         FormatterInterface $mockedFormatter)
     {
+
+        $mockedResponse->getBody()->shouldBeCalled()->willReturn($this->responseXML);
+
         $mockedHttpClient
             ->request('get',
                 'uri',
@@ -608,7 +610,7 @@ class UserPasswordSpec extends ObjectBehavior
 
         $this->request('uri', ['format' => 'xml'])->shouldReturnAnInstanceOf('SimpleXMLElement');
     }
-
+    
     public function it_should_format_header(
         ClientInterface $mockedHttpClient,
         ResponseInterface $mockedResponse,

--- a/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
@@ -594,10 +594,8 @@ class UserPasswordSpec extends ObjectBehavior
 
     public function it_returns_a_xml_resource(
         ClientInterface $mockedHttpClient,
-        ResponseInterface $mockedResponse,
-        FormatterInterface $mockedFormatter)
+        ResponseInterface $mockedResponse)
     {
-
         $mockedResponse->getBody()->shouldBeCalled()->willReturn($this->responseXML);
 
         $mockedHttpClient
@@ -607,18 +605,13 @@ class UserPasswordSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($mockedResponse);
 
-        $decodedXML = simplexml_load_string($this->responseXML);
-        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($decodedXML);
-
         $this->request('uri', ['format' => 'xml'])->shouldReturnAnInstanceOf('SimpleXMLElement');
     }
 
     public function it_returns_an_unformatted_resource(
         ClientInterface $mockedHttpClient,
-        ResponseInterface $mockedResponse,
-        FormatterInterface $mockedFormatter)
+        ResponseInterface $mockedResponse)
     {
-
         $mockedResponse->getBody()->shouldBeCalled()->willReturn($this->responseNone);
 
         $mockedHttpClient
@@ -628,10 +621,7 @@ class UserPasswordSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($mockedResponse);
 
-        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->responseNone);
-
         $this->request('uri', ['format' => 'none'])->shouldReturn($this->responseNone);
-
     }
 
     public function it_should_format_header(

--- a/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/UserPasswordSpec.php
@@ -73,6 +73,8 @@ class UserPasswordSpec extends ObjectBehavior
             <solution>Have you tried squring your shoulders, Gary?</solution>
         </meseek>';
 
+    protected $responseNone = 'A non formatted response';
+
     protected $token = [
         'access_token' => '00Do0000000secret',
         'instance_url' => 'https://na17.salesforce.com',
@@ -610,7 +612,28 @@ class UserPasswordSpec extends ObjectBehavior
 
         $this->request('uri', ['format' => 'xml'])->shouldReturnAnInstanceOf('SimpleXMLElement');
     }
-    
+
+    public function it_returns_an_unformatted_resource(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        FormatterInterface $mockedFormatter)
+    {
+
+        $mockedResponse->getBody()->shouldBeCalled()->willReturn($this->responseNone);
+
+        $mockedHttpClient
+            ->request('get',
+                'uri',
+                Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedFormatter->formatResponse($mockedResponse)->shouldBeCalled()->willReturn($this->responseNone);
+
+        $this->request('uri', ['format' => 'none'])->shouldReturn($this->responseNone);
+
+    }
+
     public function it_should_format_header(
         ClientInterface $mockedHttpClient,
         ResponseInterface $mockedResponse,

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -763,10 +763,6 @@ abstract class Client
     {
         if ($formatter === 'json') {
             $this->formatter = new JSONFormatter($this->tokenRepo, $this->settings);
-        } else if ($formatter === 'xml') {
-            $this->formatter = new XMLFormatter($this->tokenRepo, $this->settings);
-        } else if ($formatter === 'urlencoded') {
-            $this->formatter = new URLEncodedFormatter($this->tokenRepo, $this->settings);
         } else if ($formatter === 'none') {
             $this->formatter = new BaseFormatter($this->tokenRepo, $this->settings);
         }

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -18,6 +18,11 @@ use Omniphx\Forrest\Interfaces\FormatterInterface;
 use Omniphx\Forrest\Interfaces\RepositoryInterface;
 use Omniphx\Forrest\Interfaces\ResourceRepositoryInterface;
 
+use Omniphx\Forrest\Formatters\JSONFormatter;
+use Omniphx\Forrest\Formatters\URLEncodedFormatter;
+use Omniphx\Forrest\Formatters\XMLFormatter;
+use Omniphx\Forrest\Formatters\BaseFormatter;
+
 /**
  * API resources.
  *
@@ -192,7 +197,7 @@ abstract class Client
         } else {
             $this->parameters['headers'] = $this->formatter->setHeaders();
         }
-
+        
         if (isset($this->options['body'])) {
             if ($this->parameters['headers']['Content-Type'] == $this->formatter->getDefaultMIMEType()) {
                 $this->parameters['body'] = $this->formatter->setBody($this->options['body']);
@@ -201,6 +206,10 @@ abstract class Client
             }
         } else {
             unset($this->parameters['body']);
+        }
+
+        if ($this->options['format'] !== $this->settings['defaults']['format']) { 
+            $this->setFormatter($this->options['format']);
         }
 
         try {
@@ -743,6 +752,24 @@ abstract class Client
 
         $this->storeLatestVersion($versions);
         $this->storeConfiguredVersion($versions);
+    }
+
+    /**
+     * Overrides the default formatter set during register.
+     *
+     * @param string $formatter - Name of the formatter to use
+     */
+    protected function setFormatter($formatter)
+    {
+        if ($formatter === 'json') {
+            $this->formatter = new JSONFormatter($this->tokenRepo, $this->settings);
+        } else if ($formatter === 'xml') {
+            $this->formatter = new XMLFormatter($this->tokenRepo, $this->settings);
+        } else if ($formatter === 'urlencoded') {
+            $this->formatter = new URLEncodedFormatter($this->tokenRepo, $this->settings);
+        } else if ($formatter === 'none') {
+            $this->formatter = new BaseFormatter($this->tokenRepo, $this->settings);
+        }
     }
 
     private function storeConfiguredVersion($versions)

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -763,6 +763,8 @@ abstract class Client
     {
         if ($formatter === 'json') {
             $this->formatter = new JSONFormatter($this->tokenRepo, $this->settings);
+        } else if ($formatter === 'xml') {
+            $this->formatter = new XMLFormatter($this->tokenRepo, $this->settings);
         } else if ($formatter === 'none') {
             $this->formatter = new BaseFormatter($this->tokenRepo, $this->settings);
         }

--- a/src/Omniphx/Forrest/Formatters/BaseFormatter.php
+++ b/src/Omniphx/Forrest/Formatters/BaseFormatter.php
@@ -40,7 +40,7 @@ class BaseFormatter implements FormatterInterface
 
     public function setBody($data)
     {
-        return json_encode($data);
+        return $data;
     }
 
     public function formatResponse($response)

--- a/src/Omniphx/Forrest/Formatters/XMLFormatter.php
+++ b/src/Omniphx/Forrest/Formatters/XMLFormatter.php
@@ -41,7 +41,7 @@ class XMLFormatter implements FormatterInterface
 
     public function setBody($data)
     {
-        return json_encode($data);
+        return $data;
     }
 
     public function formatResponse($response)

--- a/src/Omniphx/Forrest/Formatters/XMLFormatter.php
+++ b/src/Omniphx/Forrest/Formatters/XMLFormatter.php
@@ -3,22 +3,45 @@
 namespace Omniphx\Forrest\Formatters;
 
 use Omniphx\Forrest\Interfaces\FormatterInterface;
+use Omniphx\Forrest\Interfaces\RepositoryInterface;
 
 class XMLFormatter implements FormatterInterface
 {
+    protected $tokenRepository;
+    protected $settings;
+    protected $headers;
     protected $mimeType = 'application/xml';
+
+    public function __construct(RepositoryInterface $tokenRepository, $settings) {
+        $this->tokenRepository = $tokenRepository;
+        $this->settings = $settings;
+    }
 
     public function setHeaders()
     {
-        $headers['Accept'] = $this->getDefaultMIMEType();
-        $headers['Content-Type'] = $this->getDefaultMIMEType();
+        $accessToken = $this->tokenRepository->get()['access_token'];
+        $tokenType   = $this->tokenRepository->get()['token_type'];
 
-        return $headers;
+        $this->headers['Accept']        = $this->getDefaultMIMEType();
+        $this->headers['Content-Type']  = $this->getDefaultMIMEType();
+        $this->headers['Authorization'] = "$tokenType $accessToken";
+
+        $this->setCompression();
+
+        return $this->headers;
+    }
+
+    private function setCompression()
+    {
+        if (!$this->settings['defaults']['compression']) return;
+
+        $this->headers['Accept-Encoding']  = $this->settings['defaults']['compressionType'];
+        $this->headers['Content-Encoding'] = $this->settings['defaults']['compressionType'];
     }
 
     public function setBody($data)
     {
-        return urlencode($data);
+        return json_encode($data);
     }
 
     public function formatResponse($response)


### PR DESCRIPTION
@omniphx This is a fix for #179 . It allows for overriding the default JSON formatter set when registering the service provider.  