### PR TITLE
Modify env vars in the readme and the config file for windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ This will publish a `config/forrest.php` file that can switch between authentica
 
 After adding the config file, update your `.env` to include the following values (details for getting a consumer key and secret are outlined below):
 ```
-CONSUMER_KEY=123455
-CONSUMER_SECRET=ABCDEF
-CALLBACK_URI=https://test.app/callback
-LOGIN_URL=https://login.salesforce.com
-USERNAME=mattjmitchener@gmail.com
-PASSWORD=password123
+SF_CONSUMER_KEY=123455
+SF_CONSUMER_SECRET=ABCDEF
+SF_CALLBACK_URI=https://test.app/callback
+SF_LOGIN_URL=https://login.salesforce.com
+SF_USERNAME=mattjmitchener@gmail.com
+SF_PASSWORD=password123
 ```
 
 >For Lumen, you should copy the config file from `src/config/config.php` and add it to a `forrest.php` configuration file under a config directory in the root of your application.

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -16,15 +16,15 @@ return [
      */
     'credentials'    => [
         //Required:
-        'consumerKey'    => env('CONSUMER_KEY'),
-        'consumerSecret' => env('CONSUMER_SECRET'),
-        'callbackURI'    => env('CALLBACK_URI'),
-        'loginURL'       => env('LOGIN_URL'),
+        'consumerKey'    => env('SF_CONSUMER_KEY'),
+        'consumerSecret' => env('SF_CONSUMER_SECRET'),
+        'callbackURI'    => env('SF_CALLBACK_URI'),
+        'loginURL'       => env('SF_LOGIN_URL'),
 
         // Only required for UserPassword authentication:
-        'username'       => env('USERNAME'),
+        'username'       => env('SF_USERNAME'),
         // Security token might need to be ammended to password unless IP Address is whitelisted
-        'password'       => env('PASSWORD'),
+        'password'       => env('SF_PASSWORD'),
     ],
 
     /*


### PR DESCRIPTION
The generic env var "USERNAME" can cause collision on windows as discovered by @comanche in [this issue](https://github.com/omniphx/forrest/issues/146#issuecomment-436732165).

This pull request adds a prefix "SF_" to all env vars in the README and in the config file.