### PR TITLE
Add a new OAuth method utilizing JWTs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "illuminate/config": "~6.0|~7.0",
         "illuminate/http" : "~6.0|~7.0",
         "illuminate/routing" : "~6.0|~7.0",
-        "guzzlehttp/guzzle": "~6.0|~7.0"
+        "guzzlehttp/guzzle": "~6.0|~7.0",
+        "firebase/php-jwt": "^5.2"
     },
     "require-dev": {
         "phpspec/phpspec": "~6.0"

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,14 @@
     ],
     "require": {
         "php": "~7.2",
+        "nesbot/carbon": "^2.0",
         "illuminate/cache" : "~6.0|~7.0",
         "illuminate/contracts" : "~6.0|~7.0",
         "illuminate/config": "~6.0|~7.0",
         "illuminate/http" : "~6.0|~7.0",
         "illuminate/routing" : "~6.0|~7.0",
-        "guzzlehttp/guzzle": "~6.0|~7.0",
-        "firebase/php-jwt": "^5.2"
+        "firebase/php-jwt": "^5.2",
+        "guzzlehttp/guzzle": "~6.0|~7.0"
     },
     "require-dev": {
         "phpspec/phpspec": "~6.0"

--- a/spec/Omniphx/Forrest/Authentications/OAuthJWTSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/OAuthJWTSpec.php
@@ -301,4 +301,23 @@ jrskEKQvdXS8iJl4zv2NtM5sCmHBrEzuIu0Hm5Mkp3IeDpi+TPtE
         $this->refresh()->shouldReturn(null);
     }
 
+    public function it_should_revoke_the_authentication_token(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse)
+    {
+        $mockedHttpClient->request(
+            'post',
+            'https://login.salesforce.com/services/oauth2/revoke',
+            [
+                'headers' => [
+                    'content-type' => 'application/x-www-form-urlencoded'
+                ],
+                'form_params' => [
+                    'token' => $this->token
+                ]
+            ])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+        $this->revoke()->shouldReturn($mockedResponse);
+    }
 }

--- a/spec/Omniphx/Forrest/Authentications/OAuthJWTSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/OAuthJWTSpec.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace spec\Omniphx\Forrest\Authentications;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
+use Omniphx\Forrest\Exceptions\TokenExpiredException;
+use Omniphx\Forrest\Interfaces\EncryptorInterface;
+use Omniphx\Forrest\Interfaces\EventInterface;
+use Omniphx\Forrest\Interfaces\InputInterface;
+use Omniphx\Forrest\Interfaces\RedirectInterface;
+use Omniphx\Forrest\Interfaces\FormatterInterface;
+use Omniphx\Forrest\Interfaces\RepositoryInterface;
+use Omniphx\Forrest\Interfaces\ResourceRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class OAuthJWTSpec extends ObjectBehavior
+{
+    protected $token = [
+        'access_token' => '00Do0000000secret',
+        'instance_url' => 'https://na17.salesforce.com',
+        'id'           => 'https://login.salesforce.com/id/00Do0000000xxxxx/005o0000000xxxxx',
+        'token_type'   => 'Bearer',
+        'issued_at'    => '1447000236011',
+        'signature'    => 'secretsig'];
+
+    protected $settings = [
+        'authenticationFlow' => 'OAuthJWT',
+        'credentials' => [
+            'consumerKey'    => 'testingClientId',
+            'consumerSecret' => 'testingClientSecret',
+            'callbackURI'    => 'callbackURL',
+            'loginURL'       => 'https://login.salesforce.com',
+            'username'       => 'user@email.com',
+            'password'       => 'mypassword',
+        ],
+        'parameters' => [
+            'display'   => 'popup',
+            'immediate' => 'false',
+            'state'     => '',
+            'scope'     => '',
+        ],
+        'instanceURL' => '',
+        'authRedirect' => 'redirectURL',
+        'version' => '30.0',
+        'defaults' => [
+            'method'          => 'get',
+            'format'          => 'json',
+            'compression'     => false,
+            'compressionType' => 'gzip',
+        ],
+        'language' => 'en_US',
+    ];
+
+    public function let(
+        ClientInterface $mockedHttpClient,
+        EncryptorInterface $mockedEncryptor,
+        EventInterface $mockedEvent,
+        InputInterface $mockedInput,
+        RedirectInterface $mockedRedirect,
+        ResponseInterface $mockedResponse,
+        RepositoryInterface $mockedInstanceURLRepo,
+        RepositoryInterface $mockedRefreshTokenRepo,
+        ResourceRepositoryInterface $mockedResourceRepo,
+        RepositoryInterface $mockedStateRepo,
+        RepositoryInterface $mockedTokenRepo,
+        RepositoryInterface $mockedVersionRepo,
+        FormatterInterface $mockedFormatter)
+    {
+        $this->beConstructedWith(
+            $mockedHttpClient,
+            $mockedEncryptor,
+            $mockedEvent,
+            $mockedInput,
+            $mockedRedirect,
+            $mockedInstanceURLRepo,
+            $mockedRefreshTokenRepo,
+            $mockedResourceRepo,
+            $mockedStateRepo,
+            $mockedTokenRepo,
+            $mockedVersionRepo,
+            $mockedFormatter,
+            $this->settings);
+
+        $mockedInstanceURLRepo->get()->willReturn('https://instance.salesforce.com');
+
+        $mockedResourceRepo->get(Argument::any())->willReturn('/services/data/v30.0/resource');
+        $mockedResourceRepo->put(Argument::any())->willReturn(null);
+
+        $mockedTokenRepo->get()->willReturn($this->token);
+        $mockedTokenRepo->put($this->token)->willReturn(null);
+
+        $mockedFormatter->setBody(Argument::any())->willReturn(null);
+        $mockedFormatter->setHeaders()->willReturn([
+            'Authorization' => 'Oauth accessToken',
+            'Accept'        => 'application/json',
+            'Content-Type'  => 'application/json',
+        ]);
+        $mockedFormatter->getDefaultMIMEType()->willReturn('application/json');
+
+        $mockedVersionRepo->get()->willReturn(['url' => '/resources']);
+
+        $mockedFormatter->formatResponse($mockedResponse)->willReturn(['foo' => 'bar']);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType('Omniphx\Forrest\Authentications\OAuthJWT');
+    }
+}

--- a/spec/Omniphx/Forrest/Authentications/OAuthJWTSpec.php
+++ b/spec/Omniphx/Forrest/Authentications/OAuthJWTSpec.php
@@ -2,11 +2,14 @@
 
 namespace spec\Omniphx\Forrest\Authentications;
 
+use Carbon\Carbon;
+use Firebase\JWT\JWT;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
+use Omniphx\Forrest\Authentications\OAuthJWT;
 use Omniphx\Forrest\Exceptions\TokenExpiredException;
 use Omniphx\Forrest\Interfaces\EncryptorInterface;
 use Omniphx\Forrest\Interfaces\EventInterface;
@@ -22,6 +25,36 @@ use Psr\Http\Message\ResponseInterface;
 
 class OAuthJWTSpec extends ObjectBehavior
 {
+    protected $currentTime = '2020-01-01 00:00:00';
+    protected $jwtExpiration = '2020-01-01 00:03:00';
+
+    protected $versionArray = [
+        [
+            "label"   => "Spring 15",
+            "url"     => "/services/data/v33.0",
+            "version" => "33.0"
+        ],
+        [
+            "label"   => "Summer 15",
+            "url"     => "/services/data/v34.0",
+            "version" => "34.0"
+        ],
+        [
+            "label"   => "Winter 16",
+            "url"     => "/services/data/v35.0",
+            "version" => "35.0"
+        ]
+    ];
+
+    protected $authenticationJSON = '{
+        "access_token": "00Do0000000secret",
+        "id": "https://login.salesforce.com/id/00Do0000000xxxxx/005o0000000xxxxx",
+        "instance_url": "https://na17.salesforce.com",
+        "issued_at": "1447000236011",
+        "signature": "secretsig",
+        "token_type": "Bearer"
+    }';
+
     protected $token = [
         'access_token' => '00Do0000000secret',
         'instance_url' => 'https://na17.salesforce.com',
@@ -34,7 +67,33 @@ class OAuthJWTSpec extends ObjectBehavior
         'authenticationFlow' => 'OAuthJWT',
         'credentials' => [
             'consumerKey'    => 'testingClientId',
-            'consumerSecret' => 'testingClientSecret',
+            'consumerSecret' => '-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAxxceYYRDCpErWPqwLE9DjvAmTDoIKmX1PxawLPLY9TPeFgrG
+FHEuf/BjP30z3RUcHclCYsNeMT33Ou/T7QHpgPG6b5Er2X0+xjj89YUhLj5T3tWG
+vUGtfpuortbLDdFKgVSZYk24P0L/pgRMOTmDSEMh+rLueio0YiGFc4aE0IEWNqOL
+ZEzGGef0rew1z7Sui1lFAoPxm3WJU+0umtfwVwOnPkmUtLIGQGB2Q7n8CDyw9lk3
+4Iojjv1gEWp4bCMo6tAdjWg2DuNUmsZpIwzXpC4Xi6WJ2qUjc4exfltgDZjWCSzN
+u68oEDFWkL32zrALnHrLjbGyG9vln2TvGy1+GQIDAQABAoIBAChu+46Wi/8TaJhT
+oX/+QRxAjaahipMBzgMYGoOmdoWmGQ6k9YGlUupM6fs09FmMNf+epkrknralfRaN
+Kp9R6hhz/4c1FpC/LQaZAFbkyM5ZfjMdbpX1RsUV2/ZWTTrrLJSDl/stCaRfeQhA
+izJ8CbudVsNRn7lT5PuhDzddNJAbq4I7Hr3LoEiQy+Wxv3hkNFSTHDzP2mwyqh52
+JLGeeYk/F81sQ3ltvxQUdrD7V5vQ2h9VkQEQky65wAsm2STbSdu9hTcNCcyVv5f6
+wAkJzru/nVkoqn5hBSybLlWk7l1x6RVxKfB6xzvbPk5JDFlnkLWj2jBXkeIct1Jc
+23XibQECgYEA8Jp6nfIbCjf//QIrkVl5ad9JIcDe/FI/KQ7r1CQnNdRQzwCJg4eQ
+o9ndCeK+cTTYzX3W+q2NsSBdV6A+xuKFZjza2YJ3Q3m8RrKtA33lWURxsD3PwuzS
+sTtwXNdsW+h9HYJH7OhmjhqlBF4iTnWcNlgEqtg4HyG+2sG0bBE36ykCgYEA09SU
+T0A32USN1GMOXMtnh75/6HrX8StDkHKLqN1WTuJkqK+JCqSMRnn8lKBWbeBEk80k
+kIuzKXkb2C/MLGhpH5jGR2DfUC5Mtdw0yRZUATW5EwHcoYTG8/n/gFXIICRVaV+n
+ErlrdVN55GHvbV5tEzcQYo+qieejOjLQcXHwSXECgYEAhYJS8/36Pytf4vcnUdpC
+YxtBq3coxP6miZP8DJWbJGWSCauUouXAvwsPeoLVhl/6xdxERIm1jEoXQZ5r91SP
+DXJLRlL89vZAIULYeo2LjINMSq2h8doT98Cx0vK+8CkL9Cns22sCLWxfkRLjGoJs
+kkM5I8wjKDNDgoPmJ+lODDECgYB/w2/QfQMyYE7LExPOlEBVd2jeZ3lnVJjjvrLN
+nvI3kgT0WStm5+hTebAGVM7MZr/2BX1QUXI2SX2p3upevnrpO9QbqSoHymUqKy8L
+OhRgxm5iMHVKVjNJZDfex950xHVfoPm8KWnO0hJq1Ub7yEAxnrybNdu+YZ/pskxW
+oEo1gQKBgA1UiBkEnFvX6eYplJVe4fsvDFjaPLKDMdfKqPJTsUfzbwrzuKqBWWU/
+oKYBQx5bP3wfNtI9j5dp1kIePcDBIuaNoPzpG1+UV36Wofae2OaQGN5eA89X9hja
+jrskEKQvdXS8iJl4zv2NtM5sCmHBrEzuIu0Hm5Mkp3IeDpi+TPtE
+-----END RSA PRIVATE KEY-----',
             'callbackURI'    => 'callbackURL',
             'loginURL'       => 'https://login.salesforce.com',
             'username'       => 'user@email.com',
@@ -88,9 +147,11 @@ class OAuthJWTSpec extends ObjectBehavior
             $mockedFormatter,
             $this->settings);
 
-        $mockedInstanceURLRepo->get()->willReturn('https://instance.salesforce.com');
+        $mockedInstanceURLRepo->get()
+            ->willReturn('https://instance.salesforce.com');
 
-        $mockedResourceRepo->get(Argument::any())->willReturn('/services/data/v30.0/resource');
+        $mockedResourceRepo->get(Argument::any())
+            ->willReturn('/services/data/v30.0/resource');
         $mockedResourceRepo->put(Argument::any())->willReturn(null);
 
         $mockedTokenRepo->get()->willReturn($this->token);
@@ -106,11 +167,138 @@ class OAuthJWTSpec extends ObjectBehavior
 
         $mockedVersionRepo->get()->willReturn(['url' => '/resources']);
 
-        $mockedFormatter->formatResponse($mockedResponse)->willReturn(['foo' => 'bar']);
+        $mockedFormatter->formatResponse($mockedResponse)
+            ->willReturn(['foo' => 'bar']);
+
+        // Fake the current timestamp
+        Carbon::setTestNow($this->currentTime);
+    }
+
+    public function letGo()
+    {
+        // Reset Carbon
+        Carbon::setTestNow();
     }
 
     public function it_is_initializable()
     {
-        $this->shouldHaveType('Omniphx\Forrest\Authentications\OAuthJWT');
+        $this->shouldHaveType(OAuthJWT::class);
     }
+
+    public function it_should_authenticate(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        ResponseInterface $mockedVersionRepo,
+        FormatterInterface $mockedFormatter,
+        ResponseInterface $versionResponse,
+        Stream $body)
+    {
+        $url = 'url';
+        $mockedHttpClient->request(
+            'post',
+            $url,
+            ['form_params' => [
+                'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                'assertion' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6eyJhbGciOiJSUzI1NiJ9fQ.eyJpc3MiOiJ0ZXN0aW5nQ2xpZW50SWQiLCJhdWQiOiJ1cmwiLCJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImV4cCI6MTU3Nzg1ODU4MH0.ZVUg0DnDPwbevGBhxNn3q7WPXeJxp53Jls3I8e3TLq4JxPJbQ0KH9YagHK0rrVxtBzfxLbXJZ_EHPBGAfrj2Th1RfURFvs_padt6a1CgKiOaEqzNBNJPquGDm2I06afJsbcTXurD7BRmWWRqbW5Qd1jCyX0Lr_YZiynBoQ91N82ZEAn_IkJ6l9Yr50sMxkgunW9iB66Ah4Xj8RmQ743BNpeUUZXUMGPKJ63jwRlU-wrMyn5MGSb7iYBESvWbwTtR-EOPGBk7HWo__dRS-1J3xF5PdP41UZSPUV_mwLYyM42suTvf9H_tfbDnh6ggQQGKpJdgJOGbpSlNZOreJK7pwA'
+            ]])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedHttpClient->request(
+            'get',
+            'https://instance.salesforce.com/resources',
+            ['headers' => [
+                'Authorization' => 'Oauth accessToken',
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json'
+            ]])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $body->getContents()->shouldBeCalled()
+            ->willReturn($this->authenticationJSON);
+        $mockedResponse->getBody()->shouldBeCalled()->willReturn($body);
+
+        $mockedHttpClient->request(
+            'get',
+            'https://instance.salesforce.com/services/data',
+            ['headers' => [
+                'Authorization' => 'Oauth accessToken',
+                'Accept'        => 'application/json',
+                'Content-Type'  => 'application/json'
+            ]])
+            ->shouldBeCalled()
+            ->willReturn($versionResponse);
+
+        $mockedFormatter->formatResponse($versionResponse)->shouldBeCalled()
+            ->willReturn($this->versionArray);
+
+        $mockedVersionRepo->has()->willReturn(false);
+        $mockedVersionRepo->put([
+            "label" => "Winter 16",
+            "url" => "/services/data/v35.0",
+            "version" => "35.0"
+        ])->shouldBeCalled();
+
+        $this->authenticate($url)->shouldReturn(null);
+    }
+
+    public function it_should_refresh(
+        ClientInterface $mockedHttpClient,
+        ResponseInterface $mockedResponse,
+        ResponseInterface $mockedVersionRepo,
+        FormatterInterface $mockedFormatter,
+        ResponseInterface $versionResponse,
+        Stream $body)
+    {
+        $url = 'https://login.salesforce.com/services/oauth2/token';
+        $mockedHttpClient->request(
+            'post',
+            $url,
+            ['form_params' => [
+                'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                'assertion' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6eyJhbGciOiJSUzI1NiJ9fQ.eyJpc3MiOiJ0ZXN0aW5nQ2xpZW50SWQiLCJhdWQiOiJodHRwczpcL1wvbG9naW4uc2FsZXNmb3JjZS5jb21cL3NlcnZpY2VzXC9vYXV0aDJcL3Rva2VuIiwic3ViIjoidXNlckBlbWFpbC5jb20iLCJleHAiOjE1Nzc4NTg1ODB9.ldMUERKDZhZX9gSB8huX0Odqqs6EpOmB6Ow5URKxa6V65fOZ3fEVPrjSxTmzyIfDAShKfxFeuLIXHSanPYJzQ3C5bhP7S_HAFDHJnQFbVKPYp9IcmdJOj2U-JnMv7oDc5ejXMxF-CNzRQYN4ZOwONH7pEmW1-8QTwdFUck7QHdglWF1C6K6BLN0boyjCdrrdFCGtB-XfmxxJSfiT8MZY7uS3rWBXBLDNUx4Nn9qKiJQr5kxVY3g2zjzevR1xJgmrXZFZpw__SuQpY5F4CuLfPwcc7x9HPJCVdKsdnJKpZ4jkzb4zMocarN19bp_L2tPmjNVBQDyW6V16o1LN1pSbOg'
+            ]])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $mockedHttpClient->request(
+            'get',
+            'https://instance.salesforce.com/resources',
+            ['headers' => [
+                'Authorization' => 'Oauth accessToken',
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json'
+            ]])
+            ->shouldBeCalled()
+            ->willReturn($mockedResponse);
+
+        $body->getContents()->shouldBeCalled()
+            ->willReturn($this->authenticationJSON);
+        $mockedResponse->getBody()->shouldBeCalled()->willReturn($body);
+
+        $mockedHttpClient->request(
+            'get',
+            'https://instance.salesforce.com/services/data',
+            ['headers' => [
+                'Authorization' => 'Oauth accessToken',
+                'Accept'        => 'application/json',
+                'Content-Type'  => 'application/json'
+            ]])
+            ->shouldBeCalled()
+            ->willReturn($versionResponse);
+
+        $mockedFormatter->formatResponse($versionResponse)->shouldBeCalled()
+            ->willReturn($this->versionArray);
+
+        $mockedVersionRepo->has()->willReturn(false);
+        $mockedVersionRepo->put([
+            "label" => "Winter 16",
+            "url" => "/services/data/v35.0",
+            "version" => "35.0"
+        ])->shouldBeCalled();
+
+        $this->refresh()->shouldReturn(null);
+    }
+
 }

--- a/src/Omniphx/Forrest/Authentications/OAuth2.php
+++ b/src/Omniphx/Forrest/Authentications/OAuth2.php
@@ -4,8 +4,9 @@ namespace Omniphx\Forrest\Authentications;
 
 use Firebase\JWT\JWT;
 use Omniphx\Forrest\Client as BaseAuthentication;
+use Omniphx\Forrest\Interfaces\AuthenticationInterface;
 
-class OAuth2 extends BaseAuthentication
+class OAuth2 extends BaseAuthentication implements AuthenticationInterface
 {
     public function authenticate($url = null)
     {
@@ -42,5 +43,15 @@ class OAuth2 extends BaseAuthentication
 
         $this->storeVersion();
         $this->storeResources();
+    }
+
+    public function refresh()
+    {
+        $this->authenticate();
+    }
+
+    public function revoke()
+    {
+        // Not supported for this option
     }
 }

--- a/src/Omniphx/Forrest/Authentications/OAuth2.php
+++ b/src/Omniphx/Forrest/Authentications/OAuth2.php
@@ -4,40 +4,27 @@ namespace Omniphx\Forrest\Authentications;
 
 use Firebase\JWT\JWT;
 use Omniphx\Forrest\Client as BaseAuthentication;
-use Omniphx\Forrest\Interfaces\UserPasswordInterface;
 
 class OAuth2 extends BaseAuthentication
 {
     public function authenticate($url = null)
     {
         $domain = $url ?? $this->credentials['loginURL'];
-
-        $authToken = $this->getAuthToken($domain);
-
-        $this->tokenRepo->put($authToken);
-
-        $this->storeVersion();
-        $this->storeResources();
-    }
-
-    /**
-     * @param  String $domain
-     * @return String
-     */
-    private function getAuthToken($domain)
-    {
         $username = $this->credentials['username'];
+        // OAuth Client ID
         $consumerKey = $this->credentials['consumerKey'];
+        // Private Key
         $privateKey = $this->credentials['consumerSecret'];
 
+        $header = ['alg' => 'RS256'];
         $payload = [
             'iss' => $consumerKey,
-            'sub' => $username,
             'aud' => $domain,
+            'sub' => $username,
             'exp' => now()->addMinutes(3)->timestamp
         ];
 
-        $assertion = JWT::encode($payload, $privateKey, 'RS256');
+        $assertion = JWT::encode($payload, $privateKey, 'RS256', $header);
 
         $parameters = [
             'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
@@ -47,10 +34,13 @@ class OAuth2 extends BaseAuthentication
         // \Psr\Http\Message\ResponseInterface
         $response = $this->httpClient->request('post', $domain, $parameters);
 
-        $authTokenDecoded = json_decode($response->getBody()->getContents(), true);
+        $authToken = json_decode($response->getBody()->getContents(), true);
 
-        $this->handleAuthenticationErrors($authTokenDecoded);
+        $this->handleAuthenticationErrors($authToken);
 
-        return $authTokenDecoded;
+        $this->tokenRepo->put($authToken);
+
+        $this->storeVersion();
+        $this->storeResources();
     }
 }

--- a/src/Omniphx/Forrest/Authentications/OAuth2.php
+++ b/src/Omniphx/Forrest/Authentications/OAuth2.php
@@ -10,7 +10,7 @@ class OAuth2 extends BaseAuthentication implements AuthenticationInterface
 {
     public function authenticate($url = null)
     {
-        $domain = $url ?? $this->credentials['loginURL'];
+        $domain = $url ?? $this->credentials['loginURL'] . '/services/oauth2/token';
         $username = $this->credentials['username'];
         // OAuth Client ID
         $consumerKey = $this->credentials['consumerKey'];
@@ -22,7 +22,7 @@ class OAuth2 extends BaseAuthentication implements AuthenticationInterface
             'iss' => $consumerKey,
             'aud' => $domain,
             'sub' => $username,
-            'exp' => now()->addMinutes(3)->timestamp
+            'exp' => time() + 180
         ];
 
         $assertion = JWT::encode($payload, $privateKey, 'RS256', $header);
@@ -33,11 +33,12 @@ class OAuth2 extends BaseAuthentication implements AuthenticationInterface
         ];
 
         // \Psr\Http\Message\ResponseInterface
-        $response = $this->httpClient->request('post', $domain, $parameters);
+        $response = $this->httpClient->request('post', $domain, ['form_params' => $parameters]);
 
         $authToken = json_decode($response->getBody()->getContents(), true);
 
         $this->handleAuthenticationErrors($authToken);
+
 
         $this->tokenRepo->put($authToken);
 

--- a/src/Omniphx/Forrest/Authentications/OAuth2.php
+++ b/src/Omniphx/Forrest/Authentications/OAuth2.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Omniphx\Forrest\Authentications;
+
+use Firebase\JWT\JWT;
+use Omniphx\Forrest\Client as BaseAuthentication;
+use Omniphx\Forrest\Interfaces\UserPasswordInterface;
+
+class OAuth2 extends BaseAuthentication
+{
+    public function authenticate($url = null)
+    {
+        $domain = $url ?? $this->credentials['loginURL'];
+
+        $authToken = $this->getAuthToken($domain);
+
+        $this->tokenRepo->put($authToken);
+
+        $this->storeVersion();
+        $this->storeResources();
+    }
+
+    /**
+     * @param  String $domain
+     * @return String
+     */
+    private function getAuthToken($domain)
+    {
+        $username = $this->credentials['username'];
+        $consumerKey = $this->credentials['consumerKey'];
+        $privateKey = $this->credentials['consumerSecret'];
+
+        $payload = [
+            'iss' => $consumerKey,
+            'sub' => $username,
+            'aud' => $domain,
+            'exp' => now()->addMinutes(3)->timestamp
+        ];
+
+        $assertion = JWT::encode($payload, $privateKey, 'RS256');
+
+        $parameters = [
+            'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+            'assertion' => $assertion
+        ];
+
+        // \Psr\Http\Message\ResponseInterface
+        $response = $this->httpClient->request('post', $domain, $parameters);
+
+        $authTokenDecoded = json_decode($response->getBody()->getContents(), true);
+
+        $this->handleAuthenticationErrors($authTokenDecoded);
+
+        return $authTokenDecoded;
+    }
+}

--- a/src/Omniphx/Forrest/Authentications/OAuthJWT.php
+++ b/src/Omniphx/Forrest/Authentications/OAuthJWT.php
@@ -58,6 +58,12 @@ class OAuthJWT extends BaseAuthentication implements AuthenticationInterface
 
     public function revoke()
     {
-        // Not supported for this option
+        $accessToken = $this->tokenRepo->get();
+        $url = $this->credentials['loginURL'].'/services/oauth2/revoke';
+
+        $options['headers']['content-type'] = 'application/x-www-form-urlencoded';
+        $options['form_params']['token'] = $accessToken;
+
+        return $this->httpClient->request('post', $url, $options);
     }
 }

--- a/src/Omniphx/Forrest/Authentications/OAuthJWT.php
+++ b/src/Omniphx/Forrest/Authentications/OAuthJWT.php
@@ -6,7 +6,7 @@ use Firebase\JWT\JWT;
 use Omniphx\Forrest\Client as BaseAuthentication;
 use Omniphx\Forrest\Interfaces\AuthenticationInterface;
 
-class OAuth2 extends BaseAuthentication implements AuthenticationInterface
+class OAuthJWT extends BaseAuthentication implements AuthenticationInterface
 {
     public function authenticate($url = null)
     {

--- a/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
@@ -4,7 +4,7 @@ namespace Omniphx\Forrest\Providers;
 
 use GuzzleHttp\Client;
 use Illuminate\Support\ServiceProvider;
-use Omniphx\Forrest\Authentications\OAuth2;
+use Omniphx\Forrest\Authentications\OAuthJWT;
 use Omniphx\Forrest\Authentications\WebServer;
 use Omniphx\Forrest\Authentications\UserPassword;
 use Omniphx\Forrest\Authentications\UserPasswordSoap;
@@ -102,8 +102,8 @@ abstract class BaseServiceProvider extends ServiceProvider
             $formatter = new JSONFormatter($tokenRepo, $settings);
 
             switch ($authenticationType) {
-                case 'OAuth2':
-                    $forrest = new OAuth2(
+                case 'OAuthJWT':
+                    $forrest = new OAuthJWT(
                         $httpClient,
                         $encryptor,
                         $event,

--- a/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/BaseServiceProvider.php
@@ -4,6 +4,7 @@ namespace Omniphx\Forrest\Providers;
 
 use GuzzleHttp\Client;
 use Illuminate\Support\ServiceProvider;
+use Omniphx\Forrest\Authentications\OAuth2;
 use Omniphx\Forrest\Authentications\WebServer;
 use Omniphx\Forrest\Authentications\UserPassword;
 use Omniphx\Forrest\Authentications\UserPasswordSoap;
@@ -101,6 +102,22 @@ abstract class BaseServiceProvider extends ServiceProvider
             $formatter = new JSONFormatter($tokenRepo, $settings);
 
             switch ($authenticationType) {
+                case 'OAuth2':
+                    $forrest = new OAuth2(
+                        $httpClient,
+                        $encryptor,
+                        $event,
+                        $input,
+                        $redirect,
+                        $instanceURLRepo,
+                        $refreshTokenRepo,
+                        $resourceRepo,
+                        $stateRepo,
+                        $tokenRepo,
+                        $versionRepo,
+                        $formatter,
+                        $settings);
+                    break;
                 case 'WebServer':
                     $forrest = new WebServer(
                         $httpClient,

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -5,7 +5,7 @@
  */
 return [
     /*
-     * Options include WebServer, UserPassword, and UserPasswordSoap
+     * Options include OAuth2, WebServer, UserPassword, and UserPasswordSoap
      */
     'authentication' => 'WebServer',
 
@@ -50,7 +50,7 @@ return [
         'compression'     => false,
         'compressionType' => 'gzip',
     ],
-    
+
     'client'    =>  [
         'http_errors' => true,
         'verify'    => false,

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Configuration options for Salesforce Oath settings and REST API defaults.
+ * Configuration options for Salesforce Oauth settings and REST API defaults.
  */
 return [
     /*
@@ -13,6 +13,7 @@ return [
      * Enter your credentials
      * Username and Password are only necessary for UserPassword & UserPasswordSoap flows.
      * Likewise, callbackURI is only necessary for WebServer flow.
+     * OAuthJWT requires a key, username, and private key (SF_CONSUMER_SECRET)
      */
     'credentials'    => [
         //Required:

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -5,9 +5,9 @@
  */
 return [
     /*
-     * Options include OAuth2, WebServer, UserPassword, and UserPasswordSoap
+     * Options include WebServer, UserPassword, UserPasswordSoap, and OAuthJWT
      */
-    'authentication' => 'WebServer',
+    'authentication' => env('SF_AUTH_METHOD', 'WebServer'),
 
     /*
      * Enter your credentials
@@ -17,6 +17,7 @@ return [
     'credentials'    => [
         //Required:
         'consumerKey'    => env('SF_CONSUMER_KEY'),
+        // Consumer Secret or Private Key (if using OAuthJWT)
         'consumerSecret' => env('SF_CONSUMER_SECRET'),
         'callbackURI'    => env('SF_CALLBACK_URI'),
         'loginURL'       => env('SF_LOGIN_URL'),


### PR DESCRIPTION
This PR adds a new OAuth method using JWTs as described here:
https://help.salesforce.com/articleView?id=remoteaccess_oauth_jwt_flow.htm&type=5

Per the Salesforce documentation, this authentication method does not refresh tokens. As such, the `refresh()` method just calls `authenticate()` to generate a new token.

I manually tested this with an app that is set up for JWT auth to verify it works. I also wrote some basic tests based on examples set in other Spec files. Because JWT assertions incorporate an expiration timestamp, I imported the Carbon library and used `Carbon::setTestNow()` to freeze time so the generated assertions won't change while running tests.