### PR TITLE
Change 'format' option behavior

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -194,8 +194,10 @@ abstract class Client
 
     private function handleRequest()
     {
-        if ($this->options['format'] !== $this->settings['defaults']['format']) {
+        if (isset($this->options['format'])) {
             $this->setFormatter($this->options['format']);
+        } else {
+            $this->setFormatter($this->settings['defaults']['format']);
         }
         
         if (isset($this->options['headers'])) {
@@ -763,11 +765,11 @@ abstract class Client
      */
     protected function setFormatter($formatter)
     {
-        if ($formatter === 'json') {
+        if ($formatter === 'json' && strpos(get_class($this->formatter), 'JSONFormatter') === false) {
             $this->formatter = new JSONFormatter($this->tokenRepo, $this->settings);
-        } else if ($formatter === 'xml') {
+        } else if ($formatter === 'xml' && strpos(get_class($this->formatter), 'XMLFormatter') === false) {
             $this->formatter = new XMLFormatter($this->tokenRepo, $this->settings);
-        } else if ($formatter === 'none') {
+        } else if ($formatter === 'none' && strpos(get_class($this->formatter), 'BaseFormatter') === false) {
             $this->formatter = new BaseFormatter($this->tokenRepo, $this->settings);
         }
     }


### PR DESCRIPTION
**Relates to:** https://github.com/omniphx/forrest/pull/268 (PR) and https://github.com/omniphx/forrest/issues/264 (issue)

### Problem
I ran into some problems when doing Bulk API 2.0 operations. Basically, the 'format' needs to be set to 'none' for receiving CSV payloads from the 'failedResults' and 'successfulResults' endpoints. However, you want to make a subsequent 'json' request, the `$this->options['format'] !== $this->settings['defaults']['format']` line will prevent you from setting your format to 'json' if it is also the default in the config file (which it might be for most people).
### Solution
Instead of the code "remembering" what format you set in your last call, I think it's simpler to always check and set the correct format: If the 'format' option is specified, use that. If it's not specified, use the default from the config file.
To alleviate this, I modified setFormatter() to only set a format if it's different from the current format.