### PR TITLE
add public accessor to get instance url

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Forrest::getBaseUrl(); // https://my-instance.my.salesforce.com/services/data/v5
 #### Instance URL
 Returns the URL of the Salesforce instance.
 ```php
-Forrest::getBaseUrl(); // https://my-instance.my.salesforce.com
+Forrest::getInstanceURL(); // https://my-instance.my.salesforce.com
 ```
 
 For a complete listing of API resources, refer to the [Force.com REST API Developer's Guide](http://www.salesforce.com/us/developer/docs/api_rest/api_rest.pdf)

--- a/README.md
+++ b/README.md
@@ -447,6 +447,18 @@ Returns information about the logged-in user.
 Forrest::identity();
 ```
 
+#### Base URL
+Returns the URL of the Salesforce instance with api info.
+```php
+Forrest::getBaseUrl(); // https://my-instance.my.salesforce.com/services/data/v50.0
+```
+
+#### Instance URL
+Returns the URL of the Salesforce instance.
+```php
+Forrest::getBaseUrl(); // https://my-instance.my.salesforce.com
+```
+
 For a complete listing of API resources, refer to the [Force.com REST API Developer's Guide](http://www.salesforce.com/us/developer/docs/api_rest/api_rest.pdf)
 
 ### Custom Apex endpoints

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -680,7 +680,7 @@ abstract class Client
      * @param bool $withVersion
      * @return string
      */
-    public function instanceURL($withVersion = false)
+    public function getInstanceURL($withVersion = false)
     {
         if ($withVersion) {
             return $this->getBaseUrl();

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -677,15 +677,10 @@ abstract class Client
     /**
      * Accessor to get instance URL
      *
-     * @param bool $withVersion
      * @return string
      */
-    public function getInstanceURL($withVersion = false)
+    public function getInstanceURL()
     {
-        if ($withVersion) {
-            return $this->getBaseUrl();
-        }
-
         return $this->instanceURLRepo->get();
     }
 
@@ -749,7 +744,7 @@ abstract class Client
      */
     abstract public function revoke();
 
-    protected function getBaseUrl()
+    public function getBaseUrl()
     {
         $url = $this->instanceURLRepo->get();
         $url .= $this->versionRepo->get()['url'];

--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -675,6 +675,21 @@ abstract class Client
     }
 
     /**
+     * Accessor to get instance URL
+     *
+     * @param bool $withVersion
+     * @return string
+     */
+    public function instanceURL($withVersion = false)
+    {
+        if ($withVersion) {
+            return $this->getBaseUrl();
+        }
+
+        return $this->instanceURLRepo->get();
+    }
+
+    /**
      * Returns any resource that is available to the authenticated
      * user. Reference Force.com's REST API guide to read about more
      * methods that can be called or refence them by calling the


### PR DESCRIPTION
This pr adds a public accessor method to forrest client for accessing underlying authentication instance url.

Use Case:

I wanted to add link on my app which redirects user to some record page on salesforce