### PR TITLE
Handle Bad_OAuth_Token response

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -838,6 +838,8 @@ abstract class Client
     {
         if ($ex->hasResponse() && 401 == $ex->getResponse()->getStatusCode()) {
             throw new TokenExpiredException('Salesforce token has expired', $ex);
+        } elseif ($ex->hasResponse() && 403 == $ex->getResponse()->getStatusCode() && 'Bad_OAuth_Token' == $ex->getResponse()->getBody()->getContents()) {
+            throw new TokenExpiredException('Salesforce token has expired', $ex);
         } elseif ($ex->hasResponse()) {
             $error = json_decode($ex->getResponse()->getBody()->getContents(), true);
             $ex->getResponse()->getBody()->rewind();


### PR DESCRIPTION
While trying to resolve the issue in pull request #285 I found that `Forrest::identity()` - when called with an expired token - doesn't return a HTTP 401 response, rather it returns a 403 with a response body of `Bad_OAuth_Token`, which Forrest doesn't currently expect.

From what I've read this particular error is specific to the identity request.

My proposed fix is to explicitly handle this case in `assignExceptions()` so that `identity()` calls work the same as everything else.