### PR TITLE
Revoke needs only access token

### DIFF
--- a/src/Omniphx/Forrest/Authentications/OAuthJWT.php
+++ b/src/Omniphx/Forrest/Authentications/OAuthJWT.php
@@ -58,7 +58,7 @@ class OAuthJWT extends BaseAuthentication implements AuthenticationInterface
 
     public function revoke()
     {
-        $accessToken = $this->tokenRepo->get();
+        $accessToken = $this->tokenRepo->get()['access_token'];
         $url = $this->credentials['loginURL'].'/services/oauth2/revoke';
 
         $options['headers']['content-type'] = 'application/x-www-form-urlencoded';


### PR DESCRIPTION
The `revoke` method gets the whole token info from the repo (`access_token`, `scope`, `instance_url`, etc.) but the service needs only the `access_token` to be passed.

WebServer does it well, see: https://github.com/omniphx/forrest/blob/master/src/Omniphx/Forrest/Authentications/WebServer.php#L129

(Problem also seems to be in the UserPassword)