### PR TITLE
Parse CSV response form Salesforce response.

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -788,6 +788,8 @@ abstract class Client
             $this->formatter = new XMLFormatter($this->tokenRepo, $this->settings);
         } else if ($formatter === 'none' && strpos(get_class($this->formatter), 'BaseFormatter') === false) {
             $this->formatter = new BaseFormatter($this->tokenRepo, $this->settings);
+        } elseif ($formatter === 'csv' && strpos(get_class($this->formatter), 'CsvFormatter') === false) {
+            $this->formatter = new CsvFormatter($this->tokenRepo, $this->settings);
         }
     }
 

--- a/src/Omniphx/Forrest/Formatters/CsvFormatter.php
+++ b/src/Omniphx/Forrest/Formatters/CsvFormatter.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Omniphx\Forrest\Formatters;
+
+use Omniphx\Forrest\Interfaces\FormatterInterface;
+
+class CsvFormatter implements FormatterInterface
+{
+    protected $tokenRepository;
+    protected $settings;
+    protected $headers;
+    protected $mimeType = 'application/json';
+    protected $acceptMimeType = 'text/csv';
+
+    public function __construct($tokenRepository, $settings) {
+        $this->tokenRepository = $tokenRepository;
+        $this->settings = $settings;
+    }
+
+    public function setHeaders()
+    {
+        $accessToken = $this->tokenRepository->get()['access_token'];
+        $tokenType   = $this->tokenRepository->get()['token_type'];
+
+        $this->headers['Accept']        = $this->getDefaultAcceptMIMEType();
+        $this->headers['Content-Type']  = $this->getDefaultMIMEType();
+        $this->headers['Authorization'] = "$tokenType $accessToken";
+
+        $this->setCompression();
+
+        return $this->headers;
+    }
+
+    private function setCompression()
+    {
+        if (!$this->settings['defaults']['compression']) return;
+
+        $this->headers['Accept-Encoding']  = $this->settings['defaults']['compressionType'];
+        $this->headers['Content-Encoding'] = $this->settings['defaults']['compressionType'];
+    }
+
+    public function setBody($data)
+    {
+        return $data;
+    }
+
+    public function formatResponse($response)
+    {
+        $body = $response->getBody();
+        $contents = (string) $body;
+        return $contents;
+    }
+
+    public function getDefaultMIMEType()
+    {
+        return $this->mimeType;
+    }
+
+    public function getDefaultAcceptMIMEType()
+    {
+        return $this->acceptMimeType;
+    }
+}


### PR DESCRIPTION
To get CSV format response from SF JOB successful response, below code will work after this pull request.

$response = Forrest::get('/services/data/v53.0/jobs/ingest/[JobID]/successfulResults', [], ['format' => 'csv']);