### PR TITLE
Wrap error message with missing call to sprintf(...)

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -853,7 +853,7 @@ abstract class Client
             $jsonError = json_encode($error,JSON_PRETTY_PRINT);
             throw new SalesforceException($jsonError, $ex);
         } else {
-            throw new SalesforceException('Invalid request: %s', $ex);
+            throw new SalesforceException(sprintf('Invalid request: %s', $ex->getMessage()), $ex);
         }
     }
 }


### PR DESCRIPTION
Currently the SalesforceException can be thrown with the message "Invalid request: %s".
It seems like the intended behavior was to wrap the message with a call to sprintf(...).

With this change we pass the exception message of the previous exception to the formatted error message.

Exception message before this change: `Invalid request: %s`

Exception message after this change: `Invalid request: cURL error 28: Resolving timed out after 1001 milliseconds (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)` 