### PR TITLE
adding Laravel 9.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     "require": {
         "php": "~7.2 || ~8.0",
         "firebase/php-jwt": "^5.2",
-        "illuminate/cache" : "~6.0|~7.0|~8.0",
-        "illuminate/contracts" : "~6.0|~7.0|~8.0",
-        "illuminate/config": "~6.0|~7.0|~8.0",
-        "illuminate/http" : "~6.0|~7.0|~8.0",
-        "illuminate/routing" : "~6.0|~7.0|~8.0",
+        "illuminate/cache" : "~6.0|~7.0|~8.0|~9.0",
+        "illuminate/contracts" : "~6.0|~7.0|~8.0|~9.0",
+        "illuminate/config": "~6.0|~7.0|~8.0|~9.0",
+        "illuminate/http" : "~6.0|~7.0|~8.0|~9.0",
+        "illuminate/routing" : "~6.0|~7.0|~8.0|~9.0",
         "nesbot/carbon": "^2.0",
         "guzzlehttp/guzzle": "~6.0|~7.0"
     },


### PR DESCRIPTION
Laravel 9.0 release is imminent (beta is already tagged). This adds support for illuminate/* packages v9.x.