### PR TITLE
Fix breaking change with php-jwt 6.1.0

### DIFF
--- a/src/Omniphx/Forrest/Authentications/OAuthJWT.php
+++ b/src/Omniphx/Forrest/Authentications/OAuthJWT.php
@@ -11,7 +11,6 @@ class OAuthJWT extends BaseAuthentication implements AuthenticationInterface
 {
     public static function getJWT($iss, $aud, $sub, $privateKey)
     {
-        $header = ['alg' => 'RS256'];
         $payload = [
             'iss' => $iss,
             'aud' => $aud,
@@ -19,7 +18,7 @@ class OAuthJWT extends BaseAuthentication implements AuthenticationInterface
             'exp' => Carbon::now()->addMinutes(3)->timestamp
         ];
 
-        return JWT::encode($payload, $privateKey, 'RS256', $header);
+        return JWT::encode($payload, $privateKey, 'RS256');
     }
 
     public function authenticate($url = null)


### PR DESCRIPTION
Hi! The latest release of php-jwt (6.1.0) breaks the oAuthJWT method.

`Forrest::authenticate();` throw an error:

```
TypeError
Firebase\JWT\JWT::encode(): Argument #4 ($keyId) must be of type ?string, array given, called in *****/vendor/omniphx/forrest/src/Omniphx/Forrest/Authentications/OAuthJWT.php on line 22 
```
Checking these changes I see that the `alg` param is the third only and it's not necessary to pass it as fourth param (which is the KeyId param) so I removed the $header variable/param.
https://github.com/firebase/php-jwt/blob/fbb2967a3a68b07e37678c00c0cf51165051495f/src/JWT.php#L182