### PR TITLE
Passing null to class_exists() is deprecated in php 8.1

### DIFF
--- a/src/Omniphx/Forrest/Providers/Laravel/ForrestServiceProvider.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/ForrestServiceProvider.php
@@ -42,7 +42,7 @@ class ForrestServiceProvider extends BaseServiceProvider
             case 'object':
                 return new ObjectStorage();
             default:
-                if(class_exists($storageType) && new $storageType() instanceof StorageInterface) {
+                if($storageType !== null && class_exists($storageType) && new $storageType() instanceof StorageInterface) {
                     return new $storageType();
                 } else {
                     return new LaravelSession(app('config'), app('request')->session());


### PR DESCRIPTION
Following error is occuring if no storage type been set in configuration.

**Error:**
class_exists(): Passing null to parameter #1 ($class) of type string is deprecated in /var/www/vendor/omniphx/forrest/src/Omniphx/Forrest/Providers/Laravel/ForrestServiceProvider.php on line 45

**Php:**
php -v
PHP 8.1.16 (cli) (built: Feb 23 2023 12:59:08) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.16, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.16, Copyright (c), by Zend Technologies

**Fix:**
Check if $storageType is null before checking if class exists.