### PR TITLE
Add missed class property to avoid PHP warning

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -118,6 +118,12 @@ abstract class Client implements AuthenticationInterface
      */
     protected $credentials;
 
+    /** @var \Omniphx\Forrest\Interfaces\RepositoryInterface  */
+    protected $instanceURLRepo;
+
+    /** @var \Omniphx\Forrest\Interfaces\RepositoryInterface  */
+    protected $refreshTokenRepo;
+
     /**
      * Request options.
      *

--- a/src/Omniphx/Forrest/Providers/Laravel/LaravelCache.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/LaravelCache.php
@@ -13,6 +13,7 @@ class LaravelCache implements StorageInterface
     protected $path;
     protected $seconds = 600; // 10 minutes
     protected $storeForever;
+    protected $expirationConfig;
 
     public function __construct(Config $config, Cache $cache)
     {

--- a/src/Omniphx/Forrest/Providers/Lumen/LumenCache.php
+++ b/src/Omniphx/Forrest/Providers/Lumen/LumenCache.php
@@ -13,6 +13,7 @@ class LumenCache implements StorageInterface
     protected $path;
     protected $minutes = 20;
     protected $storeForever;
+    protected $expirationConfig;
 
     public function __construct(Cache $cache, Config $config)
     {


### PR DESCRIPTION
Fix PHP 8.2 [deprecation warnings on undefined properties ](https://wiki.php.net/rfc/undefined_property_error_promotion)

**Error example:**
> `Creation of dynamic property Omniphx\\Forrest\\Providers\\Laravel\\LaravelCache::$expirationConfig is deprecated in xxx`