### PR TITLE
Add lightning and sandbox capability to OAuthJWT

### DIFF
--- a/src/Omniphx/Forrest/Authentications/OAuthJWT.php
+++ b/src/Omniphx/Forrest/Authentications/OAuthJWT.php
@@ -21,24 +21,24 @@ class OAuthJWT extends BaseAuthentication implements AuthenticationInterface
         return JWT::encode($payload, $privateKey, 'RS256');
     }
 
-    public function authenticate($url = null)
+    public function authenticate($fullInstanceUrl = null)
     {
-        $domain = $url ?? $this->credentials['loginURL'] . '/services/oauth2/token';
-        $username = $this->credentials['username'];
-        // OAuth Client ID
+        $fullInstanceUrl = $fullInstanceUrl ?? $this->getInstanceURL() . '/services/oauth2/token';
+
         $consumerKey = $this->credentials['consumerKey'];
-        // Private Key
+        $loginUrl = $this->credentials['loginURL'];
+        $username = $this->credentials['username'];
         $privateKey = $this->credentials['privateKey'];
 
         // Generate the form parameters
-        $assertion = static::getJWT($consumerKey, $domain, $username, $privateKey);
+        $assertion = static::getJWT($consumerKey, $loginUrl, $username, $privateKey);
         $parameters = [
             'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
             'assertion' => $assertion
         ];
 
         // \Psr\Http\Message\ResponseInterface
-        $response = $this->httpClient->request('post', $domain, ['form_params' => $parameters]);
+        $response = $this->httpClient->request('post', $fullInstanceUrl, ['form_params' => $parameters]);
 
         $authToken = json_decode($response->getBody()->getContents(), true);
 


### PR DESCRIPTION
Update the the OAuthJWT authentication type to work for Lightning, Lightning Sandboxes and the Developer Edition.

## Lightning Example

**config/forrest.php**
```php
return [
    // ...
    'credentials' => [
        'loginURL' => 'https://login.salesforce.com',
        'consumerKey' => '<YOUR_KEY_HERE>',
        'username' => '<EMAIL>',
        'privateKey' => '<PRIVATE_KEY>',
    ],

    'instanceURL' => 'https://<YOUR_ORG>.my.salesforce.com',
    // ...
];
```

## Lightning Sandbox Example

**config/forrest.php**
```php
return [
    // ...
    'credentials' => [
        'loginURL' => 'https://test.salesforce.com',
        'consumerKey' => '<YOUR_KEY_HERE>',
        'username' => '<EMAIL>.<SANDBOX_NAME>',
        'privateKey' => '<PRIVATE_KEY>',
    ],

    'instanceURL' => 'https://<YOUR_ORG>--<SANDBOX_NAME>.sandbox.my.salesforce.com',
    // ...
];
```

## Salesforce Developer Edition Example

**config/forrest.php**
return [
```php
    // ...
    'credentials' => [
        'loginURL' => 'https://test.salesforce.com',
        'consumerKey' => '<YOUR_KEY_HERE>',
        'username' => '<EMAIL>',
        'privateKey' => '<PRIVATE_KEY>',
    ],

    'instanceURL' => 'https://<DEV_DOMAIN>.develop.my.salesforce.com',
    // ...
];
```