### PR TITLE
Add missing callback function in Forrest Facade

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -46,7 +46,7 @@ use Omniphx\Forrest\Formatters\CsvFormatter;
  * @method string|array compactLayouts(string $resource, array $options = [])
  * @method string|array flexiPage(string $resource, array $options = [])
  * @method string|array knowledgeManagement(string $resource, array $options = [])
- * @method string|array sobjects(string $resource, array $options = [])
+ * @method string|array sobjects(string $resource = "", array $options = [])
  * @method string|array actions(string $resource, array $options = [])
  * @method string|array support(string $resource, array $options = [])
  *
@@ -212,13 +212,13 @@ abstract class Client implements AuthenticationInterface
         } else {
             $this->setFormatter($this->settings['defaults']['format']);
         }
-        
+
         if (isset($this->options['headers'])) {
             $this->parameters['headers'] = array_replace_recursive($this->formatter->setHeaders(), $this->options['headers']);
         } else {
             $this->parameters['headers'] = $this->formatter->setHeaders();
         }
-        
+
         if (isset($this->options['body'])) {
             if ($this->parameters['headers']['Content-Type'] == $this->formatter->getDefaultMIMEType()) {
                 $this->parameters['body'] = $this->formatter->setBody($this->options['body']);
@@ -228,13 +228,13 @@ abstract class Client implements AuthenticationInterface
         } else {
             unset($this->parameters['body']);
         }
-        
+
         if (isset($this->options['query'])) {
             $this->parameters['query'] = http_build_query($this->options['query']);
         } else {
             unset($this->parameters['query']);
         }
-        
+
         if (isset($this->options['json'])) {
             $this->parameters['json'] = $this->options['json'];
         } else {

--- a/src/Omniphx/Forrest/Providers/Laravel/Facades/Forrest.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/Facades/Forrest.php
@@ -51,12 +51,10 @@ use Illuminate\Support\Facades\Facade;
  * @method static string|array compactLayouts(string $resource, array $options = [])
  * @method static string|array flexiPage(string $resource, array $options = [])
  * @method static string|array knowledgeManagement(string $resource, array $options = [])
- * @method static string|array sobjects(string $resource, array $options = [])
+ * @method static string|array sobjects(string $resource = "", array $options = [])
  * @method static string|array actions(string $resource, array $options = [])
  * @method static string|array support(string $resource, array $options = [])
- * @method static \GuzzleHttp\ClientInterface getClient()
- * @method static string getInstanceURL()
- * @method static string getBaseUrl()
+ * @method static \Omniphx\Forrest\Interfaces\RedirectInterface callback()
 */
 class Forrest extends Facade
 {


### PR DESCRIPTION
Added the missing `callback()` function to the Facade when using WebServer as authentication type.

Also updated the `sobjects()` method signature to make the first parameter optional.