### PR TITLE
Remove backslashes the response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "marcelo2605/forrest",
+    "name": "omniphx/forrest",
     "description": "A Laravel library for Salesforce",
     "license": "MIT",
     "keywords": [

--- a/src/Omniphx/Forrest/Authentications/WebServer.php
+++ b/src/Omniphx/Forrest/Authentications/WebServer.php
@@ -53,8 +53,9 @@ class WebServer extends Client implements WebServerInterface
     {
         //Salesforce sends us an authorization code as part of the Web Server OAuth Authentication Flow
         $code = $this->input->get('code');
+        $state = stripslashes($this->input->get('state'));
 
-        $stateOptions = json_decode(urldecode($this->input->get('state')), true);
+        $stateOptions = json_decode(urldecode($state), true);
 
         //Store instance URL
         $loginURL = $stateOptions['loginUrl'];


### PR DESCRIPTION
The `state` value is returning with backslashes, making it impossible for the value to be interpreted correctly.

I'm using the package in an unconventional environment: WordPress + [Acorn](https://roots.io/acorn/). But I believe that the added function will not cause any harm.