### PR TITLE
added raw format in order to return unformated guzzle response

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -247,6 +247,11 @@ abstract class Client implements AuthenticationInterface
             $this->assignExceptions($ex);
         }
 
+        // If the format is raw, return the response as is
+        if($this->options['format'] == 'raw') {
+            return $response;
+        }
+
         $formattedResponse = $this->formatter->formatResponse($response);
 
         $this->event->fire('forrest.response', [$formattedResponse]);


### PR DESCRIPTION
Hey there, 
small pull request to introduces the option to retrieve the raw Guzzle response by adding format = 'raw'.