### PR TITLE
Add `Macroable` to `Client`

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -5,6 +5,7 @@ namespace Omniphx\Forrest;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Traits\Macroable;
 use Omniphx\Forrest\Exceptions\InvalidLoginCreditialsException;
 use Omniphx\Forrest\Exceptions\SalesforceException;
 use Omniphx\Forrest\Exceptions\TokenExpiredException;
@@ -53,6 +54,10 @@ use Psr\Http\Message\ResponseInterface;
  */
 abstract class Client implements AuthenticationInterface
 {
+    use Macroable {
+        __call as macroable__call;
+    }
+
     /**
      * HTTP request client.
      *
@@ -718,6 +723,10 @@ abstract class Client implements AuthenticationInterface
      */
     public function __call($name, $arguments)
     {
+        if ($this->hasMacro($name)) {
+            return $this->macroable__call($name, $arguments);
+        }
+
         $url = $this->instanceURLRepo->get();
         $url .= $this->resourceRepo->get($name);
         $url .= $this->appendURL($arguments);

--- a/src/Omniphx/Forrest/Providers/Laravel/Facades/Forrest.php
+++ b/src/Omniphx/Forrest/Providers/Laravel/Facades/Forrest.php
@@ -59,6 +59,7 @@ use Psr\Http\Message\ResponseInterface;
  * @method static ResponseInterface getAttachmentBody(string $id)
  * @method static ResponseInterface getContentVersionBody(string $id)
  * @method static \Omniphx\Forrest\Interfaces\RedirectInterface callback()
+ * @method static void macro(string $name, object|callable $macro)
  */
 class Forrest extends Facade
 {

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -123,6 +123,17 @@ class ClientTest extends TestCase
         $this->assertSame('macro test', $client->test());
     }
 
+    public function testStaticMacroable(): void
+    {
+        $client = $this->makeClient();
+
+        $client->macro('test', function () {
+            return 'macro test';
+        });
+
+        $this->assertSame('macro test', $client::test());
+    }
+
     private function makeClient(?ClientInterface $http = null, ?EventInterface $event = null, ?RepositoryInterface $tokenRepo = null): InspectableClient
     {
         $http = $http ?: $this->createMock(ClientInterface::class);

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -112,6 +112,17 @@ class ClientTest extends TestCase
         $this->assertSame(['theme' => 'mobile'], $client->theme('mobile'));
     }
 
+    public function testMacroable(): void
+    {
+        $client = $this->makeClient();
+
+        $client->macro('test', function () {
+            return 'macro test';
+        });
+
+        $this->assertSame('macro test', $client->test());
+    }
+
     private function makeClient(?ClientInterface $http = null, ?EventInterface $event = null, ?RepositoryInterface $tokenRepo = null): InspectableClient
     {
         $http = $http ?: $this->createMock(ClientInterface::class);


### PR DESCRIPTION
Thanks for the package! It is very helpful. 

One thing that the Facade is missing that a lot of other Laravel Facades has is the ability to _add macros_. 

This pulls in Illuminate's `Macroable`, and implements it with the existing `__call` functionality. 

Let me know if you'd like any changes.