### PR TITLE
Restore request options when retrying after token refresh

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -198,6 +198,7 @@ abstract class Client implements AuthenticationInterface
             $this->refresh();
 
             $this->url = $url;
+            $this->options = array_replace_recursive($this->settings['defaults'], $options);
 
             return $this->handleRequest();
         }

--- a/tests/Fixtures/ResourceRefreshingClient.php
+++ b/tests/Fixtures/ResourceRefreshingClient.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Fixtures;
+
+class ResourceRefreshingClient extends InspectableClient
+{
+    /**
+     * Mirrors the side effect of an OAuth refresh: re-fetching the resource
+     * listing issues a nested request that overwrites $this->options,
+     * which Client::request() must restore before retrying.
+     */
+    public function refresh()
+    {
+        parent::refresh();
+
+        $this->resources(['format' => 'json']);
+    }
+}

--- a/tests/Unit/Authentications/AuthenticationTest.php
+++ b/tests/Unit/Authentications/AuthenticationTest.php
@@ -201,6 +201,57 @@ class AuthenticationTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testOauthJwtRetryAfterTokenExpiryRepeatsOriginalRequest(): void
+    {
+        // OAuthJWT::refresh() re-runs authenticate(), which re-fetches the version and resource
+        // listings. Those nested requests overwrite the client's in-flight request state, so
+        // the retry after a mid-request 401 must still repeat the original method and body.
+        $calls = [];
+
+        $http = $this->createMock(ClientInterface::class);
+        $http->expects($this->exactly(5))
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $options) use (&$calls) {
+                $calls[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+                return match (count($calls)) {
+                    // initial POST: token expired
+                    1 => throw $this->requestException(401),
+                    // refresh -> authenticate(): new token
+                    2 => $this->jsonResponse([
+                        'access_token' => 'token',
+                        'instance_url' => 'https://instance.salesforce.com',
+                        'id' => 'https://login.salesforce.com/id/org/user',
+                        'token_type' => 'Bearer',
+                    ]),
+                    // refresh -> storeVersion()
+                    3 => $this->jsonResponse([
+                        ['label' => 'Winter 24', 'url' => '/services/data/v59.0', 'version' => '59.0'],
+                    ]),
+                    // refresh -> storeResources()
+                    4 => $this->jsonResponse(['query' => '/services/data/v59.0/query']),
+                    // retried POST succeeds
+                    default => $this->jsonResponse(['id' => '001']),
+                };
+            });
+
+        $client = $this->makePasswordStyleClient(OAuthJWT::class, $http, $this->tokenRepo());
+
+        $response = $client->sobjects('Account', [
+            'method' => 'post',
+            'body' => ['Name' => 'Dunder Mifflin'],
+        ]);
+
+        $this->assertSame(['id' => '001'], $response);
+
+        // The retry (fifth HTTP call) must repeat the original request the refresh interrupted.
+        $initial = $calls[0];
+        $retry = $calls[4];
+        $this->assertSame('post', $retry['method']);
+        $this->assertSame($initial['url'], $retry['url']);
+        $this->assertSame('{"Name":"Dunder Mifflin"}', $retry['options']['body']);
+    }
+
     public function testUserPasswordSoapTransformsSoapLoginResponses(): void
     {
         $http = $this->createMock(ClientInterface::class);

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -11,6 +11,7 @@ use Omniphx\Forrest\Interfaces\RedirectInterface;
 use Omniphx\Forrest\Interfaces\RepositoryInterface;
 use Omniphx\Forrest\Interfaces\ResourceRepositoryInterface;
 use Tests\Fixtures\InspectableClient;
+use Tests\Fixtures\ResourceRefreshingClient;
 use Tests\TestCase;
 
 class ClientTest extends TestCase
@@ -65,6 +66,44 @@ class ClientTest extends TestCase
 
         $this->assertSame(['id' => '001'], $client->query('SELECT Id FROM Account'));
         $this->assertSame(1, $client->refreshCalls);
+    }
+
+    public function testRequestRestoresOriginalUrlAndOptionsAfterTokenExpiry(): void
+    {
+        $calls = [];
+
+        $http = $this->createMock(ClientInterface::class);
+        $http->expects($this->exactly(3))
+            ->method('request')
+            ->willReturnCallback(function ($method, $url, $parameters) use (&$calls) {
+                $calls[] = ['method' => $method, 'url' => $url, 'parameters' => $parameters];
+
+                return match (count($calls)) {
+                    // initial POST: token expired
+                    1 => throw $this->requestException(401),
+                    // refresh re-fetches resources
+                    2 => $this->jsonResponse(['sobjects' => '/services/data/v59.0/sobjects']),
+                    // retried POST succeeds
+                    default => $this->jsonResponse(['id' => '001']),
+                };
+            });
+
+        $client = $this->makeClient($http, clientClass: ResourceRefreshingClient::class);
+
+        $response = $client->sobjects('Account', [
+            'method' => 'post',
+            'body' => ['Name' => 'Dunder Mifflin'],
+        ]);
+
+        $this->assertSame(['id' => '001'], $response);
+        $this->assertSame(1, $client->refreshCalls);
+
+        // The retry (third HTTP call) must repeat the original request url and options
+        $retry = $calls[2];
+        $this->assertSame('post', $retry['method']);
+        $this->assertSame('https://instance.salesforce.com/services/data/v59.0/sobjects/Account', $retry['url']);
+        $this->assertArrayHasKey('body', $retry['parameters']);
+        $this->assertSame('{"Name":"Dunder Mifflin"}', $retry['parameters']['body']);
     }
 
     public function testRequestCanReturnRawResponses(): void
@@ -134,7 +173,7 @@ class ClientTest extends TestCase
         $this->assertSame('macro test', $client::test());
     }
 
-    private function makeClient(?ClientInterface $http = null, ?EventInterface $event = null, ?RepositoryInterface $tokenRepo = null): InspectableClient
+    private function makeClient(?ClientInterface $http = null, ?EventInterface $event = null, ?RepositoryInterface $tokenRepo = null, string $clientClass = InspectableClient::class): InspectableClient
     {
         $http = $http ?: $this->createMock(ClientInterface::class);
         $event = $event ?: $this->createStub(EventInterface::class);
@@ -153,7 +192,7 @@ class ClientTest extends TestCase
             ['sobjects', '/services/data/v59.0/sobjects'],
         ]);
 
-        return new InspectableClient(
+        return new $clientClass(
             $http,
             $this->createStub(EncryptorInterface::class),
             $event,


### PR DESCRIPTION
## Problem

When a request returns a `401`, the `Client::request()` calls `refresh()` and retries.

For some auth methods the `authenticate()` re-fetches the version and resource listings via nested `request()` calls. Those nested calls overwrite the shared `$this->options`.

The catch block restored `$this->url` but not `$this->options`:

```php
public function request($url, $options)
{
    $this->url = $url;
    $this->options = array_replace_recursive($this->settings['defaults'], $options);

    try {
        return $this->handleRequest();
    } catch (TokenExpiredException $e) {
        $this->refresh();

        // $url restored, but not $options
        $this->url = $url;

        return $this->handleRequest();
    }
}
```

In our situation, this turned a composite `POST` into a `GET /services/data/vXX.0/composite`, which returns the composite resource directory rather than a `compositeResponse`.

## Fix

Restore the original url and options before the retry:

```php
$this->url = $url;
$this->options = array_replace_recursive($this->settings['defaults'], $options);
```

The assignment is unconditional: it fixes the re-authenticating methods and is a harmless no-op for the others.

## Tests

- `ClientTest`: an auth-agnostic contract test at the `Client::request` level, using a fixture whose `refresh()` clobbers `$this->options` via a nested request.
- `AuthenticationTest`: an end-to-end test of an `OAuthJWT` refresh path (initial POST, 401, token, versions, resources, retry).